### PR TITLE
fix: lazy initialization for CLI option overrides

### DIFF
--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -4,8 +4,19 @@ import { sleep } from 'bun';
 import { AbiCoder, keccak256, toUtf8Bytes } from 'ethers'; // ethers v6+
 import PQueue from 'p-queue';
 import { TronWeb } from 'tronweb';
-import { DEFAULT_CONFIG, NODE_URL } from './config';
+import { DEFAULT_CONFIG } from './config';
 import { createLogger } from './logger';
+
+const log = createLogger('rpc');
+
+/** Get NODE_URL at runtime to support CLI overrides */
+function getNodeUrl(): string {
+    const url = process.env.NODE_URL;
+    if (!url) {
+        throw new Error('NODE_URL environment variable is not set.');
+    }
+    return url;
+}
 
 const log = createLogger('rpc');
 
@@ -201,7 +212,7 @@ async function makeJsonRpcRequest(
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
 
     try {
-        const res = await fetch(NODE_URL, {
+        const res = await fetch(getNodeUrl(), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body),
@@ -306,7 +317,7 @@ async function makeJsonRpcCall(
                 attempt,
                 maxAttempts: attempts,
                 error: err.message,
-                endpoint: NODE_URL,
+                endpoint: getNodeUrl(),
                 context: errorContext,
             });
 
@@ -374,7 +385,7 @@ async function makeBatchJsonRpcRequest(
     const timer = setTimeout(() => ctrl.abort(), timeoutMs);
 
     try {
-        const res = await fetch(NODE_URL, {
+        const res = await fetch(getNodeUrl(), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(body),
@@ -509,7 +520,7 @@ export async function makeBatchJsonRpcCall(
                 attempt,
                 maxAttempts: attempts,
                 error: err.message,
-                endpoint: NODE_URL,
+                endpoint: getNodeUrl(),
             });
 
             // Exponential backoff with jitter

--- a/lib/service-init.ts
+++ b/lib/service-init.ts
@@ -7,13 +7,8 @@ import { initBatchInsertQueue } from './batch-insert';
 import {
     BATCH_INSERT_INTERVAL_MS,
     BATCH_INSERT_MAX_SIZE,
-    CLICKHOUSE_DATABASE,
-    CLICKHOUSE_URL,
     CONCURRENCY,
-    LOG_LEVEL,
-    NODE_URL,
-    PROMETHEUS_HOSTNAME,
-    PROMETHEUS_PORT,
+    DEFAULT_CONFIG,
 } from './config';
 import { createLogger } from './logger';
 
@@ -39,17 +34,23 @@ export function initService(options: ServiceInitOptions): void {
     });
 
     // Log startup info (always at INFO level)
+    // Read env vars at runtime to capture CLI overrides
     if (!serviceInitialized) {
         log.info('Service starting', {
             service: options.serviceName,
             config: {
-                LOG_LEVEL,
-                CLICKHOUSE_URL,
-                CLICKHOUSE_DATABASE,
-                NODE_URL,
+                LOG_LEVEL: process.env.LOG_LEVEL ?? 'info',
+                CLICKHOUSE_URL:
+                    process.env.CLICKHOUSE_URL ?? DEFAULT_CONFIG.CLICKHOUSE_URL,
+                CLICKHOUSE_DATABASE: process.env.CLICKHOUSE_DATABASE,
+                NODE_URL: process.env.NODE_URL,
                 CONCURRENCY,
-                PROMETHEUS_PORT,
-                PROMETHEUS_HOSTNAME,
+                PROMETHEUS_PORT:
+                    process.env.PROMETHEUS_PORT ??
+                    DEFAULT_CONFIG.PROMETHEUS_PORT,
+                PROMETHEUS_HOSTNAME:
+                    process.env.PROMETHEUS_HOSTNAME ??
+                    DEFAULT_CONFIG.PROMETHEUS_HOSTNAME,
                 BATCH_INSERT_INTERVAL_MS,
                 BATCH_INSERT_MAX_SIZE,
             },


### PR DESCRIPTION
- ClickHouse client now initializes lazily on first use instead of at module load time
- RPC module uses getNodeUrl() function to read NODE_URL at runtime
- service-init reads env vars directly from process.env for logging

This fixes the issue where CLI options like --clickhouse-database and --node-url were being ignored because the config values were captured at module import time before the CLI had a chance to set them.