### PR TITLE
Cleanup clickhouse connections

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -2,7 +2,7 @@
 import { Command } from 'commander';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { closeAllClients } from './lib/clickhouse';
+import { client } from './lib/clickhouse';
 import { DEFAULT_CONFIG } from './lib/config';
 import { createLogger } from './lib/logger';
 import { startPrometheusServer, stopPrometheusServer } from './lib/prometheus';
@@ -338,7 +338,7 @@ async function runService(serviceName: string, options: ServiceOptions) {
             }
 
             // Close ClickHouse connections to allow event loop to be idle
-            await closeAllClients();
+            await client.close();
 
             // Wait before restarting
             log.info(

--- a/lib/clickhouse.ts
+++ b/lib/clickhouse.ts
@@ -123,34 +123,6 @@ export const client = {
     },
 };
 
-/**
- * Close all ClickHouse client connections and reset references
- * This allows the event loop to be idle and enables clean service restarts
- */
-export async function closeAllClients(): Promise<void> {
-    const clients: ClickHouseClient[] = [];
-
-    if (_client) {
-        clients.push(_client);
-        _client = null;
-    }
-    if (_insertClient) {
-        clients.push(_insertClient);
-        _insertClient = null;
-    }
-    if (_setupClient) {
-        clients.push(_setupClient);
-        _setupClient = null;
-    }
-
-    if (clients.length > 0) {
-        await Promise.all(clients.map((c) => c.close()));
-        log.debug('Closed all ClickHouse client connections', {
-            count: clients.length,
-        });
-    }
-}
-
 export interface TokenData {
     token: string;
     token_symbol: string;


### PR DESCRIPTION
This pull request improves resource management for ClickHouse client connections in the service runner. The main change is the introduction of a utility to close all active ClickHouse clients, ensuring clean shutdowns and allowing the event loop to become idle before service restarts.

**Resource management improvements:**

* Added a new `closeAllClients` function in `lib/clickhouse.ts` to close all active ClickHouse client connections and reset their references for clean shutdowns.
* Updated `cli.ts` to import and call `closeAllClients` after service execution, ensuring connections are closed before waiting for a restart. [[1]](diffhunk://#diff-34610464905445a5c4c85ac0f5f0c6e5c1491d074f895606359e1c5b82390cc7R5) [[2]](diffhunk://#diff-34610464905445a5c4c85ac0f5f0c6e5c1491d074f895606359e1c5b82390cc7R340-R342)