### PR TITLE
fix(polymarket): handle Gamma API closed default change

### DIFF
--- a/services/polymarket/index.test.ts
+++ b/services/polymarket/index.test.ts
@@ -766,12 +766,19 @@ describe('Polymarket markets service', () => {
             }),
         );
 
-        // First request returns market, second returns empty (not found)
+        // First request returns market; second returns empty (not found),
+        // then retry with closed=true also returns empty
         mockFetch
             .mockReturnValueOnce(
                 Promise.resolve({
                     ok: true,
                     json: () => Promise.resolve([mockMarket]),
+                }),
+            )
+            .mockReturnValueOnce(
+                Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve([]),
                 }),
             )
             .mockReturnValueOnce(
@@ -786,8 +793,8 @@ describe('Polymarket markets service', () => {
         await run();
 
         expect(mockQuery).toHaveBeenCalled();
-        // Should make TWO fetch calls (one per condition_id)
-        expect(mockFetch).toHaveBeenCalledTimes(2);
+        // 3 fetch calls: found market, not-found market, not-found retry with closed=true
+        expect(mockFetch).toHaveBeenCalledTimes(3);
         // Should insert 1 market and 1 error
         expect(mockInsertRow).toHaveBeenCalledTimes(2);
         expect(mockInsertRow).toHaveBeenCalledWith(
@@ -812,6 +819,62 @@ describe('Polymarket markets service', () => {
         expect(mockIncrementSuccess).toHaveBeenCalledTimes(1);
         expect(mockIncrementError).toHaveBeenCalledTimes(1);
         expect(mockShutdownBatchInsertQueue).toHaveBeenCalled();
+    });
+
+    test('should find closed market on retry with closed=true', async () => {
+        const registeredTokens = [
+            {
+                condition_id: '0xclosed111111111111111111111111111111111111111111111111111111111',
+                token0: '111',
+                token1: '222',
+                timestamp: '2025-06-01 00:00:00',
+                block_hash: '0xaaa',
+                block_num: 99999,
+            },
+        ];
+
+        const closedMarket = {
+            ...baseMockMarket,
+            id: '999',
+            conditionId: '0xclosed111111111111111111111111111111111111111111111111111111111',
+            question: 'Resolved market?',
+            slug: 'resolved-market',
+            closed: true,
+            active: false,
+        };
+
+        mockQuery.mockReturnValueOnce(
+            Promise.resolve({
+                data: registeredTokens,
+                metrics: { httpRequestTimeMs: 0, dataFetchTimeMs: 0, totalTimeMs: 0 },
+            }),
+        );
+
+        // First fetch (open markets) returns empty, retry with closed=true finds it
+        mockFetch
+            .mockReturnValueOnce(
+                Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
+            )
+            .mockReturnValueOnce(
+                Promise.resolve({ ok: true, json: () => Promise.resolve([closedMarket]) }),
+            );
+
+        const { run } = await import('./index');
+        await run();
+
+        // 2 fetch calls: initial (empty) + retry with closed=true (found)
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+        expect(mockInsertRow).toHaveBeenCalledWith(
+            'polymarket_markets',
+            expect.objectContaining({
+                condition_id: '0xclosed111111111111111111111111111111111111111111111111111111111',
+                closed: true,
+            }),
+            expect.any(String),
+            expect.any(Object),
+        );
+        expect(mockIncrementSuccess).toHaveBeenCalledTimes(1);
+        expect(mockIncrementError).not.toHaveBeenCalled();
     });
 
     test('should handle negative commentCount by converting to 0', async () => {

--- a/services/polymarket/index.ts
+++ b/services/polymarket/index.ts
@@ -257,21 +257,34 @@ async function fetchGammaApi<T>(
     }
 }
 
-function fetchMarketFromApi(conditionId: string) {
-    return fetchGammaApi<PolymarketMarket>(
-        `/markets?condition_ids=${conditionId}&limit=1`,
-        { conditionId },
-    ).then((r) => r[0] ?? null);
+function buildMarketParams(ids: string[], closed?: boolean) {
+    const params = new URLSearchParams();
+    for (const id of ids) params.append('condition_ids', id);
+    params.set('limit', String(ids.length));
+    if (closed) params.set('closed', 'true');
+    return params;
 }
 
-function fetchMarketsFromApi(conditionIds: string[]) {
-    const params = new URLSearchParams();
-    for (const id of conditionIds) params.append('condition_ids', id);
-    params.set('limit', String(conditionIds.length));
-    return fetchGammaApi<PolymarketMarket>(
-        `/markets?${params}`,
-        { conditionIds: String(conditionIds.length) },
+async function fetchMarketFromApi(conditionId: string) {
+    const results = await fetchMarketsFromApi([conditionId]);
+    return results[0] ?? null;
+}
+
+async function fetchMarketsFromApi(conditionIds: string[]) {
+    const ctx = { conditionIdCount: String(conditionIds.length) };
+    const results = await fetchGammaApi<PolymarketMarket>(
+        `/markets?${buildMarketParams(conditionIds)}`,
+        ctx,
     );
+    if (results.length >= conditionIds.length) return results;
+    const foundIds = new Set(results.map((m) => m.conditionId));
+    const missingIds = conditionIds.filter((id) => !foundIds.has(id));
+    if (missingIds.length === 0) return results;
+    const closedResults = await fetchGammaApi<PolymarketMarket>(
+        `/markets?${buildMarketParams(missingIds, true)}`,
+        ctx,
+    );
+    return [...results, ...closedResults];
 }
 
 function fetchEventFromApi(eventSlug: string) {
@@ -736,7 +749,11 @@ async function processEventEnrichment(eventSlug: string): Promise<void> {
     if (missingIds.length === 0) {
         await insertRow(
             'polymarket_events_enriched',
-            { slug: eventSlug, markets_found: event.markets.length, markets_inserted: 0 },
+            {
+                slug: eventSlug,
+                markets_found: event.markets.length,
+                markets_inserted: 0,
+            },
             `Failed to record enrichment for ${eventSlug}`,
             {},
         );
@@ -747,7 +764,10 @@ async function processEventEnrichment(eventSlug: string): Promise<void> {
     const markets = await fetchMarketsFromApi(missingIds);
     if (markets.length === 0) {
         // API failure or none resolved — don't record, allow retry
-        log.debug('Batch market fetch returned nothing', { eventSlug, missingCount: missingIds.length });
+        log.debug('Batch market fetch returned nothing', {
+            eventSlug,
+            missingCount: missingIds.length,
+        });
         return;
     }
     let inserted = 0;


### PR DESCRIPTION
## Summary

- Polymarket Gamma API changed `GET /markets` to default `closed=false` as of April 9, 2026 ([changelog](https://docs.polymarket.com/changelog#apr-9-2026))
- This silently excludes resolved markets from responses, even when querying by specific `condition_id`
- The scraper now retries with `closed=true` when the initial fetch returns fewer results than requested
- Extracted `buildMarketParams` helper to consolidate URL parameter construction
- `fetchMarketFromApi` now delegates to `fetchMarketsFromApi`, eliminating duplicate retry logic

## Test plan

- [x] Existing tests updated for retry behavior (3 fetch calls when market not found)
- [x] New test: closed market successfully found on `closed=true` retry
- [x] 11/11 tests passing
- [x] Verified against live Gamma API: `condition_ids` lookup for a resolved market returns `[]` without `closed=true`, returns the market with it

🤖 Generated with [Claude Code](https://claude.com/claude-code)