### PR TITLE
fix(polymarket): add fetch timeout and make request delay configurable

### DIFF
--- a/services/polymarket/index.ts
+++ b/services/polymarket/index.ts
@@ -10,9 +10,24 @@ import { initService } from '../../lib/service-init';
 import { insertRow } from '../../src/insert';
 
 /**
- * Delay between requests in milliseconds to avoid overwhelming the API
+ * Delay between requests in milliseconds to avoid overwhelming the API.
+ * Configurable via POLYMARKET_REQUEST_DELAY_MS. Default raised from 100ms
+ * to 250ms to reduce 429 pressure under Gamma's per-IP rate limits.
  */
-const REQUEST_DELAY_MS = 100;
+const REQUEST_DELAY_MS = parseInt(
+    process.env.POLYMARKET_REQUEST_DELAY_MS || '250',
+    10,
+);
+
+/**
+ * Per-request timeout for Gamma API calls. Without this, a stalled TCP
+ * connection (which Polymarket occasionally emits when heavily rate-limited)
+ * can hang the entire PQueue and deadlock the scraper.
+ */
+const FETCH_TIMEOUT_MS = parseInt(
+    process.env.POLYMARKET_FETCH_TIMEOUT_MS || '30000',
+    10,
+);
 
 const serviceName = 'polymarket';
 const log = createLogger(serviceName);
@@ -236,7 +251,9 @@ async function fetchGammaApi<T>(
     const url = `${POLYMARKET_API_BASE}${path}`;
 
     try {
-        const response = await fetch(url);
+        const response = await fetch(url, {
+            signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
         if (!response.ok) {
             log.warn('Polymarket API returned non-OK status', {
                 path,


### PR DESCRIPTION
## Summary

\`fetchGammaApi\` used a bare \`fetch(url)\` with no timeout. When Gamma stalls a connection (TCP accepted but no response emitted) instead of returning an HTTP status, the promise never settles, \`PQueue.onIdle()\` never resolves, and the scraper's outer \`while(true)\` loop never ticks. Because the liveness/readiness probes hit a separate \`/metrics\` port that stays up independently of the worker, Kubernetes sees the pod as healthy and doesn't restart it.

## Changes

- **Fetch timeout.** Wrap the Gamma \`fetch()\` call with \`AbortSignal.timeout(FETCH_TIMEOUT_MS)\`. A stalled request now aborts and falls into the existing \`catch\` path, which logs a warning and returns \`[]\` — the same graceful degradation we already have for non-2xx responses.
- **Configurable request pacing.** Replace the hardcoded \`REQUEST_DELAY_MS = 100\` with \`parseInt(process.env.POLYMARKET_REQUEST_DELAY_MS ?? '250')\`. Default bumped to 250ms to leave more headroom under Gamma's per-IP rate limits; overridable without a rebuild if we need to tune further.
- **Configurable fetch timeout.** New \`POLYMARKET_FETCH_TIMEOUT_MS\` env var, default 30s.

No behavior change for a healthy Gamma API — the affected code paths only fire when a fetch stalls or when the loop is pacing between requests.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)