### PR TITLE
test(polymarket): isolate normalizeGammaTimestamp tests from mocked suite

### DIFF
--- a/services/polymarket/index.test.ts
+++ b/services/polymarket/index.test.ts
@@ -81,44 +81,6 @@ const baseMockMarket = {
     bestBid: 0, bestAsk: 0, umaResolutionStatuses: '',
 };
 
-describe('normalizeGammaTimestamp', () => {
-    test('strips microsecond precision from Z-suffixed timestamps', async () => {
-        const { normalizeGammaTimestamp } = await import('./index');
-        expect(normalizeGammaTimestamp('2026-04-22T23:20:10.368406Z')).toBe(
-            '2026-04-22T23:20:10Z',
-        );
-    });
-
-    test('strips fractional seconds with numeric offsets', async () => {
-        const { normalizeGammaTimestamp } = await import('./index');
-        expect(normalizeGammaTimestamp('2026-04-22T23:20:10.5+00:00')).toBe(
-            '2026-04-22T23:20:10+00:00',
-        );
-        expect(normalizeGammaTimestamp('2026-04-22T23:20:10.123-05:00')).toBe(
-            '2026-04-22T23:20:10-05:00',
-        );
-    });
-
-    test('passes already-whole-second timestamps through unchanged', async () => {
-        const { normalizeGammaTimestamp } = await import('./index');
-        expect(normalizeGammaTimestamp('2026-04-22T23:20:10Z')).toBe(
-            '2026-04-22T23:20:10Z',
-        );
-        expect(normalizeGammaTimestamp('2026-04-22 14:54:44')).toBe(
-            '2026-04-22 14:54:44',
-        );
-    });
-
-    test('returns epoch sentinel for empty or missing input', async () => {
-        const { normalizeGammaTimestamp } = await import('./index');
-        expect(normalizeGammaTimestamp('')).toBe('1970-01-01T00:00:00Z');
-        expect(normalizeGammaTimestamp(undefined)).toBe(
-            '1970-01-01T00:00:00Z',
-        );
-        expect(normalizeGammaTimestamp(null)).toBe('1970-01-01T00:00:00Z');
-    });
-});
-
 describe('Polymarket markets service', () => {
     beforeEach(() => {
         mockQuery.mockClear();

--- a/services/polymarket/normalize.test.ts
+++ b/services/polymarket/normalize.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizeGammaTimestamp } from './index';
+
+// Isolated from services/polymarket/index.test.ts so the mock.module setup
+// there doesn't race with these pure-function tests under concurrent
+// bun test load.
+describe('normalizeGammaTimestamp', () => {
+    test('strips microsecond precision from Z-suffixed timestamps', () => {
+        expect(normalizeGammaTimestamp('2026-04-22T23:20:10.368406Z')).toBe(
+            '2026-04-22T23:20:10Z',
+        );
+    });
+
+    test('strips fractional seconds with numeric offsets', () => {
+        expect(normalizeGammaTimestamp('2026-04-22T23:20:10.5+00:00')).toBe(
+            '2026-04-22T23:20:10+00:00',
+        );
+        expect(normalizeGammaTimestamp('2026-04-22T23:20:10.123-05:00')).toBe(
+            '2026-04-22T23:20:10-05:00',
+        );
+    });
+
+    test('passes already-whole-second timestamps through unchanged', () => {
+        expect(normalizeGammaTimestamp('2026-04-22T23:20:10Z')).toBe(
+            '2026-04-22T23:20:10Z',
+        );
+        expect(normalizeGammaTimestamp('2026-04-22 14:54:44')).toBe(
+            '2026-04-22 14:54:44',
+        );
+    });
+
+    test('returns epoch sentinel for empty or missing input', () => {
+        expect(normalizeGammaTimestamp('')).toBe('1970-01-01T00:00:00Z');
+        expect(normalizeGammaTimestamp(undefined)).toBe(
+            '1970-01-01T00:00:00Z',
+        );
+        expect(normalizeGammaTimestamp(null)).toBe('1970-01-01T00:00:00Z');
+    });
+});


### PR DESCRIPTION
## Summary

The \`normalizeGammaTimestamp\` tests added in #289 used \`await import('./index')\` inside the same file that sets up \`mock.module\` for the service's dependencies. That dynamic import races with the mock loader under concurrent bun-test load — CI was green on #289's PR run but red after squash-merge to main (same code, different load order).

Moves the four pure-function tests into a new \`services/polymarket/normalize.test.ts\` that imports directly and doesn't set up any mocks. The existing mocked suite stays focused on the service entry points.

No behavior change to the scraper itself.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)