### PR TITLE
fix(polymarket): strip trailing Z / tz offset from Gamma timestamps

### DIFF
--- a/services/polymarket/index.ts
+++ b/services/polymarket/index.ts
@@ -46,13 +46,16 @@ const serviceName = 'polymarket';
 const log = createLogger(serviceName);
 
 /**
- * Strip fractional seconds from a Gamma ISO 8601 timestamp so it fits
- * ClickHouse `DateTime('UTC')` columns. Gamma returns microsecond precision
- * (e.g. `2026-04-22T23:20:10.368406Z`) which CH's DateTime parser rejects.
+ * Normalize a Gamma ISO 8601 timestamp so it fits ClickHouse
+ * `DateTime('UTC')` columns. CH's DateTime parser accepts
+ * `YYYY-MM-DD HH:MM:SS` or `YYYY-MM-DDTHH:MM:SS` but rejects fractional
+ * seconds and the trailing `Z` / `±HH:MM` offset Gamma tacks on, so strip
+ * both. A caller that feeds chain-sourced "YYYY-MM-DD HH:MM:SS" already
+ * matches the accepted shape and passes through unchanged.
  */
 export function normalizeGammaTimestamp(s: string | undefined | null): string {
-    if (!s) return '1970-01-01T00:00:00Z';
-    return s.replace(/\.\d+(Z|[+-]\d{2}:?\d{2})?$/, '$1');
+    if (!s) return '1970-01-01T00:00:00';
+    return s.replace(/\.\d+/, '').replace(/(Z|[+-]\d{2}:?\d{2})$/, '');
 }
 
 /**

--- a/services/polymarket/normalize.test.ts
+++ b/services/polymarket/normalize.test.ts
@@ -5,35 +5,36 @@ import { normalizeGammaTimestamp } from './index';
 // there doesn't race with these pure-function tests under concurrent
 // bun test load.
 describe('normalizeGammaTimestamp', () => {
-    test('strips microsecond precision from Z-suffixed timestamps', () => {
+    test('strips microsecond precision and trailing Z', () => {
         expect(normalizeGammaTimestamp('2026-04-22T23:20:10.368406Z')).toBe(
-            '2026-04-22T23:20:10Z',
+            '2026-04-22T23:20:10',
         );
     });
 
-    test('strips fractional seconds with numeric offsets', () => {
+    test('strips fractional seconds and numeric offsets', () => {
         expect(normalizeGammaTimestamp('2026-04-22T23:20:10.5+00:00')).toBe(
-            '2026-04-22T23:20:10+00:00',
+            '2026-04-22T23:20:10',
         );
         expect(normalizeGammaTimestamp('2026-04-22T23:20:10.123-05:00')).toBe(
-            '2026-04-22T23:20:10-05:00',
+            '2026-04-22T23:20:10',
         );
     });
 
-    test('passes already-whole-second timestamps through unchanged', () => {
+    test('strips a bare Z suffix even without fractional seconds', () => {
         expect(normalizeGammaTimestamp('2026-04-22T23:20:10Z')).toBe(
-            '2026-04-22T23:20:10Z',
+            '2026-04-22T23:20:10',
         );
+    });
+
+    test('passes chain-sourced space-separated timestamps through unchanged', () => {
         expect(normalizeGammaTimestamp('2026-04-22 14:54:44')).toBe(
             '2026-04-22 14:54:44',
         );
     });
 
     test('returns epoch sentinel for empty or missing input', () => {
-        expect(normalizeGammaTimestamp('')).toBe('1970-01-01T00:00:00Z');
-        expect(normalizeGammaTimestamp(undefined)).toBe(
-            '1970-01-01T00:00:00Z',
-        );
-        expect(normalizeGammaTimestamp(null)).toBe('1970-01-01T00:00:00Z');
+        expect(normalizeGammaTimestamp('')).toBe('1970-01-01T00:00:00');
+        expect(normalizeGammaTimestamp(undefined)).toBe('1970-01-01T00:00:00');
+        expect(normalizeGammaTimestamp(null)).toBe('1970-01-01T00:00:00');
     });
 });


### PR DESCRIPTION
## Summary

The normalizer from #289 stripped fractional seconds (\`.368406Z\` → \`Z\`) but left the trailing \`Z\` untouched. ClickHouse's \`DateTime('UTC')\` parser rejects the \`Z\` suffix (\`syntax error at position 19\`), so enrichment-path inserts continued failing silently on prod v0.3.12 — same symptom as before my earlier fix, just a different character.

## Root cause

CH \`DateTime('UTC')\` accepts \`YYYY-MM-DD HH:MM:SS\` or \`YYYY-MM-DDTHH:MM:SS\` but nothing else — not fractional seconds, not \`Z\`, not \`±HH:MM\`. The normalizer needs to strip both, not just fractions.

## Fix

Two \`.replace()\` calls instead of one:
\`\`\`ts
return s.replace(/\.\d+/, '').replace(/(Z|[+-]\d{2}:?\d{2})$/, '');
\`\`\`

Handles every Gamma shape we see in the wild:
- \`2025-05-02T15:03:10.397014Z\` → \`2025-05-02T15:03:10\`
- \`2026-04-22T23:20:10.5Z\` → \`2026-04-22T23:20:10\`
- \`2026-04-22T23:20:10Z\` → \`2026-04-22T23:20:10\` (bare Z case missed before)
- \`2026-04-22T23:20:10+00:00\` → \`2026-04-22T23:20:10\`
- \`2026-04-22 14:54:44\` → unchanged (chain-sourced passthrough)

## Verification

Beyond the 5 unit tests:

- Audited every DateTime column in \`sql.schemas/schema.polymarket.sql\` — only \`polymarket_markets.timestamp\` takes user input; the others are \`DEFAULT now()\`.
- Audited every insert path — the table is only written from \`insertMarket()\`, which now routes through the normalizer. Main / enrichment / refresh passes all share that code path.
- End-to-end live test: pulled a real Gamma market (\`createdAt = 2025-05-02T15:03:10.397014Z\`), ran it through the normalizer, inserted the row into the production \`polymarket.polymarket_markets\` table with sink credentials — succeeded.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)