### PR TITLE
Add clickhouse timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+launch.json

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -25,6 +25,11 @@ cp .env.example .env
 - **`CLICKHOUSE_DATABASE`** - ClickHouse database name
   - Default: `default`
 
+- **`CLICKHOUSE_REQUEST_TIMEOUT_MS`** - Timeout in milliseconds for ClickHouse HTTP requests
+  - Default: `30000` (30 seconds)
+  - Guards against indefinitely hung queries — particularly important when running under Bun, which does not send TCP keepalive probes via `http.Agent`, meaning a silently dead connection (e.g. NAT table expiry in Kubernetes) would otherwise hang forever
+  - Increase if your ClickHouse queries legitimately take longer than 30 seconds
+
 ### RPC Configuration
 
 - **`NODE_URL`** - EVM RPC node URL (required)

--- a/lib/clickhouse.ts
+++ b/lib/clickhouse.ts
@@ -1,4 +1,5 @@
 import { type ClickHouseClient, createClient } from '@clickhouse/client';
+import { CLICKHOUSE_REQUEST_TIMEOUT_MS } from './config';
 import { createLogger } from './logger';
 import { trackClickHouseOperation } from './prometheus';
 
@@ -31,6 +32,7 @@ function getClient(): ClickHouseClient {
             username: process.env.CLICKHOUSE_USERNAME || 'default',
             password: process.env.CLICKHOUSE_PASSWORD || '',
             database: process.env.CLICKHOUSE_DATABASE,
+            request_timeout: CLICKHOUSE_REQUEST_TIMEOUT_MS,
         });
     }
     return _client;
@@ -47,6 +49,7 @@ function getInsertClient(): ClickHouseClient {
             username: process.env.CLICKHOUSE_USERNAME || 'default',
             password: process.env.CLICKHOUSE_PASSWORD || '',
             database: getInsertDatabase(),
+            request_timeout: CLICKHOUSE_REQUEST_TIMEOUT_MS,
         });
     }
     return _insertClient;
@@ -64,6 +67,7 @@ function getSetupClient(): ClickHouseClient {
             username: process.env.CLICKHOUSE_USERNAME || 'default',
             password: process.env.CLICKHOUSE_PASSWORD || '',
             database: getInsertDatabase(),
+            request_timeout: CLICKHOUSE_REQUEST_TIMEOUT_MS,
         });
     }
     return _setupClient;
@@ -149,6 +153,15 @@ export async function query<T = any>(
     // Track total operation time
     const startTime = performance.now();
 
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => {
+        controller.abort(
+            new Error(
+                `ClickHouse query timed out after ${CLICKHOUSE_REQUEST_TIMEOUT_MS}ms`,
+            ),
+        );
+    }, CLICKHOUSE_REQUEST_TIMEOUT_MS);
+
     try {
         // Track query execution time
         const queryStartTime = performance.now();
@@ -156,6 +169,7 @@ export async function query<T = any>(
             query,
             query_params,
             format: 'JSONEachRow',
+            abort_signal: controller.signal,
         });
         trackClickHouseOperation('read', 'success', startTime);
         const queryEndTime = performance.now();
@@ -182,6 +196,7 @@ export async function query<T = any>(
             totalTimeMs,
         });
 
+        clearTimeout(timeoutHandle);
         return {
             data,
             metrics: {
@@ -191,6 +206,7 @@ export async function query<T = any>(
             },
         };
     } catch (error: unknown) {
+        clearTimeout(timeoutHandle);
         trackClickHouseOperation('read', 'error', startTime);
         const url = process.env.CLICKHOUSE_URL || 'http://localhost:8123';
         const urlObj = new URL(url);

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -40,6 +40,9 @@ export const DEFAULT_CONFIG = {
 
     // Auto-restart
     AUTO_RESTART_DELAY: 10,
+
+    // ClickHouse request timeout
+    CLICKHOUSE_REQUEST_TIMEOUT_MS: 30_000,
 } as const;
 
 // ============================================================================
@@ -111,6 +114,16 @@ export const CLICKHOUSE_USERNAME =
 export const CLICKHOUSE_PASSWORD =
     process.env.CLICKHOUSE_PASSWORD || DEFAULT_CONFIG.CLICKHOUSE_PASSWORD;
 export const CLICKHOUSE_DATABASE = process.env.CLICKHOUSE_DATABASE;
+
+/**
+ * Timeout in milliseconds for ClickHouse HTTP requests
+ * Default: 30000ms (30 seconds)
+ */
+export const CLICKHOUSE_REQUEST_TIMEOUT_MS = parseInt(
+    process.env.CLICKHOUSE_REQUEST_TIMEOUT_MS ||
+        String(DEFAULT_CONFIG.CLICKHOUSE_REQUEST_TIMEOUT_MS),
+    10,
+);
 
 /**
  * Database name for insert operations (INSERT, DDL)

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -36,7 +36,10 @@ function transportJSON(logObj: Record<string, unknown>): void {
         logger: meta.name,
         msg,
     };
-    if (payload !== undefined && (payload === null || typeof payload !== 'object')) {
+    if (
+        payload !== undefined &&
+        (payload === null || typeof payload !== 'object')
+    ) {
         flat.data = payload;
     }
     process.stdout.write(JSON.stringify(flat) + '\n');

--- a/services/polymarket/fetch-gamma.test.ts
+++ b/services/polymarket/fetch-gamma.test.ts
@@ -12,8 +12,7 @@ const mockFetch = mock(() =>
 );
 globalThis.fetch = mockFetch as unknown as typeof fetch;
 
-const conditionId = (i: number) =>
-    `0x${i.toString(16).padStart(64, '0')}`;
+const conditionId = (i: number) => `0x${i.toString(16).padStart(64, '0')}`;
 
 const marketStub = (id: number) => ({
     id: String(id),
@@ -31,7 +30,9 @@ describe('fetchGammaApi', () => {
             Promise.resolve({
                 ok: true,
                 json: () =>
-                    Promise.resolve({ markets: [marketStub(1), marketStub(2)] }),
+                    Promise.resolve({
+                        markets: [marketStub(1), marketStub(2)],
+                    }),
             }),
         );
         const result = await fetchGammaApi(

--- a/services/polymarket/index.test.ts
+++ b/services/polymarket/index.test.ts
@@ -58,29 +58,86 @@ mock.module('../../lib/batch-insert', () => ({
 globalThis.fetch = mockFetch as unknown as typeof fetch;
 
 const baseMockMarket = {
-    id: '1', conditionId: '0xaaa', question: 'Test?', description: '',
-    slug: 'test', outcomes: '["Yes", "No"]', outcomePrices: '["0.5", "0.5"]',
-    resolutionSource: '', image: '', icon: '', questionID: '',
-    clobTokenIds: '["111", "222"]', submitted_by: '', marketMakerAddress: '',
-    enableOrderBook: true, orderPriceMinTickSize: 0.001, orderMinSize: 5,
-    negRisk: false, negRiskRequestID: '', negRiskOther: false,
-    archived: false, new: false, featured: false, resolvedBy: '',
-    restricted: false, hasReviewedDates: false, umaBond: '', umaReward: '',
-    customLiveness: 0, acceptingOrders: true, ready: true, funded: true,
-    acceptingOrdersTimestamp: '', cyom: false, competitive: 0,
-    pagerDutyNotificationEnabled: false, approved: true, rewardsMinSize: 0,
-    rewardsMaxSpread: 0, spread: 0, automaticallyActive: true,
-    clearBookOnStart: false, manualActivation: false, pendingDeployment: false,
-    deploying: false, deployingTimestamp: '', rfqEnabled: false,
-    eventStartTime: '', holdingRewardsEnabled: false, feesEnabled: false,
-    requiresTranslation: false, startDate: '', endDate: '', startDateIso: '',
-    endDateIso: '', umaEndDate: '', createdAt: '', events: [] as any[],
-    liquidity: '', volume: '', volumeNum: 0, liquidityNum: 0,
-    volume24hr: 0, volume1wk: 0, volume1mo: 0, volume1yr: 0,
-    volume24hrClob: 0, volume1wkClob: 0, volume1moClob: 0, volume1yrClob: 0,
-    volumeClob: 0, liquidityClob: 0, active: true, closed: false,
-    oneDayPriceChange: 0, oneHourPriceChange: 0, lastTradePrice: 0,
-    bestBid: 0, bestAsk: 0, umaResolutionStatuses: '',
+    id: '1',
+    conditionId: '0xaaa',
+    question: 'Test?',
+    description: '',
+    slug: 'test',
+    outcomes: '["Yes", "No"]',
+    outcomePrices: '["0.5", "0.5"]',
+    resolutionSource: '',
+    image: '',
+    icon: '',
+    questionID: '',
+    clobTokenIds: '["111", "222"]',
+    submitted_by: '',
+    marketMakerAddress: '',
+    enableOrderBook: true,
+    orderPriceMinTickSize: 0.001,
+    orderMinSize: 5,
+    negRisk: false,
+    negRiskRequestID: '',
+    negRiskOther: false,
+    archived: false,
+    new: false,
+    featured: false,
+    resolvedBy: '',
+    restricted: false,
+    hasReviewedDates: false,
+    umaBond: '',
+    umaReward: '',
+    customLiveness: 0,
+    acceptingOrders: true,
+    ready: true,
+    funded: true,
+    acceptingOrdersTimestamp: '',
+    cyom: false,
+    competitive: 0,
+    pagerDutyNotificationEnabled: false,
+    approved: true,
+    rewardsMinSize: 0,
+    rewardsMaxSpread: 0,
+    spread: 0,
+    automaticallyActive: true,
+    clearBookOnStart: false,
+    manualActivation: false,
+    pendingDeployment: false,
+    deploying: false,
+    deployingTimestamp: '',
+    rfqEnabled: false,
+    eventStartTime: '',
+    holdingRewardsEnabled: false,
+    feesEnabled: false,
+    requiresTranslation: false,
+    startDate: '',
+    endDate: '',
+    startDateIso: '',
+    endDateIso: '',
+    umaEndDate: '',
+    createdAt: '',
+    events: [] as any[],
+    liquidity: '',
+    volume: '',
+    volumeNum: 0,
+    liquidityNum: 0,
+    volume24hr: 0,
+    volume1wk: 0,
+    volume1mo: 0,
+    volume1yr: 0,
+    volume24hrClob: 0,
+    volume1wkClob: 0,
+    volume1moClob: 0,
+    volume1yrClob: 0,
+    volumeClob: 0,
+    liquidityClob: 0,
+    active: true,
+    closed: false,
+    oneDayPriceChange: 0,
+    oneHourPriceChange: 0,
+    lastTradePrice: 0,
+    bestBid: 0,
+    bestAsk: 0,
+    umaResolutionStatuses: '',
 };
 
 describe('Polymarket markets service', () => {
@@ -108,7 +165,11 @@ describe('Polymarket markets service', () => {
         mockQuery.mockReturnValue(
             Promise.resolve({
                 data: [],
-                metrics: { httpRequestTimeMs: 0, dataFetchTimeMs: 0, totalTimeMs: 0 },
+                metrics: {
+                    httpRequestTimeMs: 0,
+                    dataFetchTimeMs: 0,
+                    totalTimeMs: 0,
+                },
             }),
         );
     });
@@ -831,7 +892,8 @@ describe('Polymarket markets service', () => {
     test('should find closed market on retry with closed=true', async () => {
         const registeredTokens = [
             {
-                condition_id: '0xclosed111111111111111111111111111111111111111111111111111111111',
+                condition_id:
+                    '0xclosed111111111111111111111111111111111111111111111111111111111',
                 token0: '111',
                 token1: '222',
                 timestamp: '2025-06-01 00:00:00',
@@ -843,7 +905,8 @@ describe('Polymarket markets service', () => {
         const closedMarket = {
             ...baseMockMarket,
             id: '999',
-            conditionId: '0xclosed111111111111111111111111111111111111111111111111111111111',
+            conditionId:
+                '0xclosed111111111111111111111111111111111111111111111111111111111',
             question: 'Resolved market?',
             slug: 'resolved-market',
             closed: true,
@@ -853,17 +916,27 @@ describe('Polymarket markets service', () => {
         mockQuery.mockReturnValueOnce(
             Promise.resolve({
                 data: registeredTokens,
-                metrics: { httpRequestTimeMs: 0, dataFetchTimeMs: 0, totalTimeMs: 0 },
+                metrics: {
+                    httpRequestTimeMs: 0,
+                    dataFetchTimeMs: 0,
+                    totalTimeMs: 0,
+                },
             }),
         );
 
         // First fetch (open markets) returns empty, retry with closed=true finds it
         mockFetch
             .mockReturnValueOnce(
-                Promise.resolve({ ok: true, json: () => Promise.resolve({ markets: [] }) }),
+                Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ markets: [] }),
+                }),
             )
             .mockReturnValueOnce(
-                Promise.resolve({ ok: true, json: () => Promise.resolve({ markets: [closedMarket] }) }),
+                Promise.resolve({
+                    ok: true,
+                    json: () => Promise.resolve({ markets: [closedMarket] }),
+                }),
             );
 
         const { run } = await import('./index');
@@ -874,7 +947,8 @@ describe('Polymarket markets service', () => {
         expect(mockInsertRow).toHaveBeenCalledWith(
             'polymarket_markets',
             expect.objectContaining({
-                condition_id: '0xclosed111111111111111111111111111111111111111111111111111111111',
+                condition_id:
+                    '0xclosed111111111111111111111111111111111111111111111111111111111',
                 closed: true,
             }),
             expect.any(String),
@@ -1084,21 +1158,33 @@ describe('Polymarket markets service', () => {
         mockQuery.mockReturnValueOnce(
             Promise.resolve({
                 data: [],
-                metrics: { httpRequestTimeMs: 0, dataFetchTimeMs: 0, totalTimeMs: 0 },
+                metrics: {
+                    httpRequestTimeMs: 0,
+                    dataFetchTimeMs: 0,
+                    totalTimeMs: 0,
+                },
             }),
         );
         // Second query: one event slug to enrich
         mockQuery.mockReturnValueOnce(
             Promise.resolve({
                 data: [{ event_slug: 'test-event' }],
-                metrics: { httpRequestTimeMs: 0, dataFetchTimeMs: 0, totalTimeMs: 0 },
+                metrics: {
+                    httpRequestTimeMs: 0,
+                    dataFetchTimeMs: 0,
+                    totalTimeMs: 0,
+                },
             }),
         );
         // Third query: batch existence check returns empty (no existing markets)
         mockQuery.mockReturnValueOnce(
             Promise.resolve({
                 data: [],
-                metrics: { httpRequestTimeMs: 0, dataFetchTimeMs: 0, totalTimeMs: 0 },
+                metrics: {
+                    httpRequestTimeMs: 0,
+                    dataFetchTimeMs: 0,
+                    totalTimeMs: 0,
+                },
             }),
         );
 
@@ -1114,8 +1200,14 @@ describe('Polymarket markets service', () => {
                                 slug: 'test-event',
                                 title: 'Test Event',
                                 markets: [
-                                    { conditionId: '0xaaa', question: 'Market A?' },
-                                    { conditionId: '0xbbb', question: 'Market B?' },
+                                    {
+                                        conditionId: '0xaaa',
+                                        question: 'Market A?',
+                                    },
+                                    {
+                                        conditionId: '0xbbb',
+                                        question: 'Market B?',
+                                    },
                                 ],
                             },
                         ],
@@ -1124,17 +1216,26 @@ describe('Polymarket markets service', () => {
         );
 
         // Second fetch: batch /markets/keyset returns both child markets in one call
-        const mockMarketA = { ...baseMockMarket, conditionId: '0xaaa', question: 'Market A?', slug: 'market-a' };
+        const mockMarketA = {
+            ...baseMockMarket,
+            conditionId: '0xaaa',
+            question: 'Market A?',
+            slug: 'market-a',
+        };
         const mockMarketB = {
             ...baseMockMarket,
-            id: '2', conditionId: '0xbbb', question: 'Market B?',
-            slug: 'market-b', clobTokenIds: '["333", "444"]',
+            id: '2',
+            conditionId: '0xbbb',
+            question: 'Market B?',
+            slug: 'market-b',
+            clobTokenIds: '["333", "444"]',
         };
 
         mockFetch.mockReturnValueOnce(
             Promise.resolve({
                 ok: true,
-                json: () => Promise.resolve({ markets: [mockMarketA, mockMarketB] }),
+                json: () =>
+                    Promise.resolve({ markets: [mockMarketA, mockMarketB] }),
             }),
         );
 
@@ -1142,9 +1243,7 @@ describe('Polymarket markets service', () => {
         await run();
 
         // Should insert: market A, market B, enrichment tracking record
-        const insertCalls = mockInsertRow.mock.calls.map(
-            (call) => call[0],
-        );
+        const insertCalls = mockInsertRow.mock.calls.map((call) => call[0]);
         expect(insertCalls).toContain('polymarket_markets');
         expect(insertCalls).toContain('polymarket_events_enriched');
 
@@ -1166,21 +1265,33 @@ describe('Polymarket markets service', () => {
         mockQuery.mockReturnValueOnce(
             Promise.resolve({
                 data: [],
-                metrics: { httpRequestTimeMs: 0, dataFetchTimeMs: 0, totalTimeMs: 0 },
+                metrics: {
+                    httpRequestTimeMs: 0,
+                    dataFetchTimeMs: 0,
+                    totalTimeMs: 0,
+                },
             }),
         );
         // Event slugs to enrich
         mockQuery.mockReturnValueOnce(
             Promise.resolve({
                 data: [{ event_slug: 'existing-event' }],
-                metrics: { httpRequestTimeMs: 0, dataFetchTimeMs: 0, totalTimeMs: 0 },
+                metrics: {
+                    httpRequestTimeMs: 0,
+                    dataFetchTimeMs: 0,
+                    totalTimeMs: 0,
+                },
             }),
         );
         // Batch existence check: one market already exists
         mockQuery.mockReturnValueOnce(
             Promise.resolve({
                 data: [{ condition_id: '0xaaa' }],
-                metrics: { httpRequestTimeMs: 0, dataFetchTimeMs: 0, totalTimeMs: 0 },
+                metrics: {
+                    httpRequestTimeMs: 0,
+                    dataFetchTimeMs: 0,
+                    totalTimeMs: 0,
+                },
             }),
         );
 
@@ -1196,8 +1307,14 @@ describe('Polymarket markets service', () => {
                                 slug: 'existing-event',
                                 title: 'Existing Event',
                                 markets: [
-                                    { conditionId: '0xaaa', question: 'Already scraped' },
-                                    { conditionId: '0xbbb', question: 'New market' },
+                                    {
+                                        conditionId: '0xaaa',
+                                        question: 'Already scraped',
+                                    },
+                                    {
+                                        conditionId: '0xbbb',
+                                        question: 'New market',
+                                    },
                                 ],
                             },
                         ],

--- a/services/polymarket/index.ts
+++ b/services/polymarket/index.ts
@@ -527,9 +527,7 @@ async function refreshOpenMarkets(): Promise<void> {
     }
 
     const stale = await query<RegisteredToken>(
-        await Bun.file(
-            __dirname + '/get_stale_markets_for_refresh.sql',
-        ).text(),
+        await Bun.file(__dirname + '/get_stale_markets_for_refresh.sql').text(),
         {
             db: CLICKHOUSE_DATABASE_INSERT,
             limit: REFRESH_BATCH_SIZE,


### PR DESCRIPTION
This pull request introduces a configurable timeout for ClickHouse HTTP requests to prevent indefinitely hung queries, particularly addressing issues when running under Bun. It also updates the documentation and configuration files to support this new setting. Additionally, there are various formatting improvements and minor test refactors for better readability and maintainability.

**ClickHouse request timeout improvements:**

* Added a new environment variable `CLICKHOUSE_REQUEST_TIMEOUT_MS` (default: 30,000ms) to control the timeout for ClickHouse HTTP requests, with documentation explaining its importance and usage. [[1]](diffhunk://#diff-58f184d7415a8c22e56e4908527cfd1c7c28ea1c5720cf4280b2d511b25f7409R28-R32) [[2]](diffhunk://#diff-e53d9a775fe43c0fed7503b2e2fd8d73b283b72dadc8707d3cdfc00f5e5ff732R43-R45) [[3]](diffhunk://#diff-e53d9a775fe43c0fed7503b2e2fd8d73b283b72dadc8707d3cdfc00f5e5ff732R118-R127)
* Updated ClickHouse client creation in `lib/clickhouse.ts` to use the new timeout value for all client instances. [[1]](diffhunk://#diff-e2a330f977f504d4f9fca3846ecdfc5248b74ec21d1e1ea2ecc4685c7d93332bR35) [[2]](diffhunk://#diff-e2a330f977f504d4f9fca3846ecdfc5248b74ec21d1e1ea2ecc4685c7d93332bR52) [[3]](diffhunk://#diff-e2a330f977f504d4f9fca3846ecdfc5248b74ec21d1e1ea2ecc4685c7d93332bR70)
* Implemented timeout logic in the `query` function to abort requests that exceed the configured timeout, ensuring resources are cleaned up and errors are tracked appropriately. [[1]](diffhunk://#diff-e2a330f977f504d4f9fca3846ecdfc5248b74ec21d1e1ea2ecc4685c7d93332bR156-R172) [[2]](diffhunk://#diff-e2a330f977f504d4f9fca3846ecdfc5248b74ec21d1e1ea2ecc4685c7d93332bR199) [[3]](diffhunk://#diff-e2a330f977f504d4f9fca3846ecdfc5248b74ec21d1e1ea2ecc4685c7d93332bR209)

**Documentation:**

* Updated `docs/CONFIGURATION.md` to document the new `CLICKHOUSE_REQUEST_TIMEOUT_MS` environment variable, its default value, and guidance for users.

**Test and formatting improvements:**

* Reformatted and improved readability of test data and mock responses in Polymarket service tests, including breaking up long lines and consistently formatting objects and arrays. [[1]](diffhunk://#diff-973bd8aa423416606ed77a476b89ccadc20a0ffa3221f512a2c21981789f3008L15-R15) [[2]](diffhunk://#diff-973bd8aa423416606ed77a476b89ccadc20a0ffa3221f512a2c21981789f3008L34-R35) [[3]](diffhunk://#diff-5480703a5a3faaecb8e5796b794568fd70956fb6c19ac9ecc0ee6b2c74716bb2L61-R140) [[4]](diffhunk://#diff-5480703a5a3faaecb8e5796b794568fd70956fb6c19ac9ecc0ee6b2c74716bb2L111-R172) [[5]](diffhunk://#diff-5480703a5a3faaecb8e5796b794568fd70956fb6c19ac9ecc0ee6b2c74716bb2L834-R896) [[6]](diffhunk://#diff-5480703a5a3faaecb8e5796b794568fd70956fb6c19ac9ecc0ee6b2c74716bb2L846-R909) [[7]](diffhunk://#diff-5480703a5a3faaecb8e5796b794568fd70956fb6c19ac9ecc0ee6b2c74716bb2L856-R939) [[8]](diffhunk://#diff-5480703a5a3faaecb8e5796b794568fd70956fb6c19ac9ecc0ee6b2c74716bb2L877-R951) [[9]](diffhunk://#diff-5480703a5a3faaecb8e5796b794568fd70956fb6c19ac9ecc0ee6b2c74716bb2L1087-R1187) [[10]](diffhunk://#diff-5480703a5a3faaecb8e5796b794568fd70956fb6c19ac9ecc0ee6b2c74716bb2L1117-R1210) [[11]](diffhunk://#diff-5480703a5a3faaecb8e5796b794568fd70956fb6c19ac9ecc0ee6b2c74716bb2L1127-R1246) [[12]](diffhunk://#diff-5480703a5a3faaecb8e5796b794568fd70956fb6c19ac9ecc0ee6b2c74716bb2L1169-R1294)
* Minor formatting fix in `lib/logger.ts` for improved code style consistency.