### PR TITLE
feat(hyperliquid): add spot pair name scraper

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -40,6 +40,11 @@ const SERVICES = {
         description:
             'Fetch and store Polymarket market metadata from condition_id and token0/token1',
     },
+    hyperliquid: {
+        path: './services/hyperliquid/index.ts',
+        description:
+            'Fetch and store Hyperliquid spot pair name lookups from the Info API spotMeta endpoint',
+    },
     'metadata-solana-rpc': {
         path: './services/metadata-solana-rpc/index.ts',
         description:
@@ -75,6 +80,11 @@ const SETUP_ACTIONS = {
         files: ['./sql.schemas/schema.polymarket.sql'],
         description:
             'Deploy polymarket tables (polymarket_markets, polymarket_assets)',
+    },
+    hyperliquid: {
+        files: ['./sql.schemas/schema.hyperliquid.sql'],
+        description:
+            'Deploy hyperliquid spot pair name lookup table (state_spot_pair_names)',
     },
     'forked-blocks': {
         files: ['./sql.schemas/schema.blocks_forked.sql'],
@@ -371,6 +381,7 @@ Services:
   metadata-swaps              ${SERVICES['metadata-swaps'].description}
   metadata-balances           ${SERVICES['metadata-balances'].description}
   polymarket                  ${SERVICES['polymarket'].description}
+  hyperliquid                 ${SERVICES['hyperliquid'].description}
   metadata-solana-rpc         ${SERVICES['metadata-solana-rpc'].description}
   metadata-solana-extras-rpc  ${SERVICES['metadata-solana-extras-rpc'].description}
   metadata-solana-clickhouse  ${SERVICES['metadata-solana-clickhouse'].description}
@@ -380,6 +391,7 @@ Examples:
   $ npm run cli run metadata-swaps
   $ npm run cli run metadata-balances
   $ npm run cli run polymarket
+  $ npm run cli run hyperliquid
   $ npm run cli run metadata-solana-rpc
   $ npm run cli run metadata-solana-extras-rpc
   $ npm run cli run metadata-solana-clickhouse
@@ -593,6 +605,33 @@ Example:
         await handleSetupCommand(files, options);
     });
 addClickhouseOptions(setupPolymarket);
+
+// ---- setup hyperliquid ----
+const setupHyperliquid = setupCommand
+    .command('hyperliquid')
+    .description(SETUP_ACTIONS.hyperliquid.description)
+    .addHelpText(
+        'after',
+        `
+This command deploys the Hyperliquid spot pair name lookup table.
+It only needs to be run once per database to initialize the table.
+
+Tables created:
+  - state_spot_pair_names: Resolves \`@N\` and canonical pair coin values to BASE/QUOTE strings
+
+Example:
+  $ npm run cli setup hyperliquid
+  $ npm run cli setup hyperliquid --cluster my_cluster
+`,
+    )
+    .action(async (options: any) => {
+        log.info('Setting up hyperliquid spot pair name lookup table');
+        const files = SETUP_ACTIONS.hyperliquid.files.map((f) =>
+            resolve(__dirname, f),
+        );
+        await handleSetupCommand(files, options);
+    });
+addClickhouseOptions(setupHyperliquid);
 
 // ---- setup forked-blocks ----
 const setupForkedBlocks = setupCommand

--- a/services/hyperliquid/index.test.ts
+++ b/services/hyperliquid/index.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const mockInsert = mock(() => Promise.resolve());
+const mockQuery = mock(() =>
+    Promise.resolve({
+        data: [],
+        metrics: { httpRequestTimeMs: 0, dataFetchTimeMs: 0, totalTimeMs: 0 },
+    }),
+);
+const mockIncrementSuccess = mock(() => {});
+const mockIncrementError = mock(() => {});
+const mockInitService = mock(() => {});
+
+// `mock.module` applies process-wide for the test session. Mirror the full set
+// of exports other test files mock so a later `mock.module` call in another
+// suite (e.g. polymarket) can override cleanly without leaving dangling
+// undefined imports.
+mock.module('../../lib/clickhouse', () => ({
+    insertClient: { insert: mockInsert },
+    query: mockQuery,
+}));
+
+mock.module('../../lib/prometheus', () => ({
+    incrementSuccess: mockIncrementSuccess,
+    incrementError: mockIncrementError,
+}));
+
+mock.module('../../lib/service-init', () => ({
+    initService: mockInitService,
+}));
+
+const sampleMeta = {
+    tokens: [
+        {
+            name: 'USDC',
+            fullName: null,
+            index: 0,
+            tokenId: '0x00',
+            szDecimals: 8,
+            weiDecimals: 8,
+            isCanonical: true,
+            evmContract: null,
+            deployerTradingFeeShare: '0.0',
+        },
+        {
+            name: 'HYPE',
+            fullName: null,
+            index: 150,
+            tokenId: '0x96',
+            szDecimals: 2,
+            weiDecimals: 8,
+            isCanonical: false,
+            evmContract: null,
+            deployerTradingFeeShare: '0.0',
+        },
+    ],
+    universe: [
+        {
+            tokens: [150, 0],
+            name: '@107',
+            index: 107,
+            isCanonical: false,
+        },
+    ],
+};
+
+describe('hyperliquid run()', () => {
+    const originalFetch = globalThis.fetch;
+    const originalUrl = process.env.HYPERLIQUID_INFO_URL;
+
+    beforeEach(() => {
+        mockInsert.mockClear();
+        mockIncrementSuccess.mockClear();
+        mockIncrementError.mockClear();
+        mockInitService.mockClear();
+    });
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+        if (originalUrl === undefined) {
+            delete process.env.HYPERLIQUID_INFO_URL;
+        } else {
+            process.env.HYPERLIQUID_INFO_URL = originalUrl;
+        }
+    });
+
+    test('throws when HYPERLIQUID_INFO_URL is unset', async () => {
+        delete process.env.HYPERLIQUID_INFO_URL;
+        // Re-import after env change so the module-level constant is re-read.
+        const { run } = await import(`./index?nocache=${Date.now()}`);
+        await expect(run()).rejects.toThrow(/HYPERLIQUID_INFO_URL/);
+    });
+
+    test('inserts resolved spot pair names with refresh_time', async () => {
+        process.env.HYPERLIQUID_INFO_URL = 'http://example/info';
+        globalThis.fetch = mock(() =>
+            Promise.resolve(
+                new Response(JSON.stringify(sampleMeta), { status: 200 }),
+            ),
+        ) as unknown as typeof fetch;
+
+        const { run } = await import(`./index?nocache=${Date.now()}`);
+        await run();
+
+        expect(mockInsert).toHaveBeenCalledTimes(1);
+        const arg = mockInsert.mock.calls[0]![0] as {
+            table: string;
+            values: Array<{
+                spot_coin: string;
+                pair_name: string;
+                refresh_time: string;
+            }>;
+            format: string;
+        };
+        expect(arg.table).toBe('state_spot_pair_names');
+        expect(arg.format).toBe('JSONEachRow');
+        expect(arg.values).toHaveLength(1);
+        expect(arg.values[0]!.spot_coin).toBe('@107');
+        expect(arg.values[0]!.pair_name).toBe('HYPE/USDC');
+        expect(arg.values[0]!.refresh_time).toMatch(
+            /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+        );
+        expect(mockIncrementSuccess).toHaveBeenCalledTimes(1);
+        expect(mockIncrementError).not.toHaveBeenCalled();
+    });
+
+    test('records an error metric and rethrows when fetch fails', async () => {
+        process.env.HYPERLIQUID_INFO_URL = 'http://example/info';
+        globalThis.fetch = mock(() =>
+            Promise.resolve(new Response('boom', { status: 502 })),
+        ) as unknown as typeof fetch;
+
+        const { run } = await import(`./index?nocache=${Date.now()}`);
+        await expect(run()).rejects.toThrow();
+        expect(mockIncrementError).toHaveBeenCalledTimes(1);
+        expect(mockInsert).not.toHaveBeenCalled();
+    });
+});

--- a/services/hyperliquid/index.ts
+++ b/services/hyperliquid/index.ts
@@ -1,0 +1,84 @@
+import { insertClient } from '../../lib/clickhouse';
+import { createLogger } from '../../lib/logger';
+import { incrementError, incrementSuccess } from '../../lib/prometheus';
+import { initService } from '../../lib/service-init';
+import {
+    fetchSpotMeta,
+    type HyperliquidSpotMeta,
+    resolvePairNames,
+} from './info';
+
+const serviceName = 'hyperliquid';
+const log = createLogger(serviceName);
+
+const INFO_URL = process.env.HYPERLIQUID_INFO_URL;
+
+/**
+ * Fetch the latest spot universe + tokens, resolve `@N` pair names, and
+ * snapshot all rows into `state_spot_pair_names` with a fresh `refresh_time`.
+ * The CLI runner loops with `AUTO_RESTART_DELAY` between iterations, so a
+ * single `run()` invocation maps to one poll cycle.
+ */
+export async function run(): Promise<void> {
+    initService({ serviceName });
+
+    if (!INFO_URL) {
+        throw new Error(
+            'HYPERLIQUID_INFO_URL is required (set to a Hyperliquid /info endpoint)',
+        );
+    }
+
+    log.info('Fetching spot metadata');
+    const startTime = performance.now();
+
+    let meta: HyperliquidSpotMeta;
+    try {
+        meta = await fetchSpotMeta(INFO_URL);
+    } catch (error) {
+        log.error('Failed to fetch spot metadata', { error });
+        incrementError(serviceName);
+        throw error;
+    }
+
+    const fetchTimeMs = Math.round(performance.now() - startTime);
+    const rows = resolvePairNames(meta);
+
+    log.info('Resolved spot pair names', {
+        pairs: meta.universe.length,
+        tokens: meta.tokens.length,
+        rows: rows.length,
+        fetchTimeMs,
+    });
+
+    if (rows.length === 0) {
+        log.warn('Empty spot universe — skipping insert');
+        return;
+    }
+
+    // ClickHouse DateTime('UTC') rejects the trailing `Z` and fractional
+    // seconds that toISOString() emits, so trim both.
+    const refresh_time = new Date()
+        .toISOString()
+        .slice(0, 19)
+        .replace('T', ' ');
+    const values = rows.map((r) => ({ ...r, refresh_time }));
+
+    try {
+        await insertClient.insert({
+            table: 'state_spot_pair_names',
+            values,
+            format: 'JSONEachRow',
+        });
+    } catch (error) {
+        log.error('Failed to insert spot pair names', { error });
+        incrementError(serviceName);
+        throw error;
+    }
+
+    log.info('Inserted spot pair names', { count: values.length });
+    incrementSuccess(serviceName);
+}
+
+if (import.meta.main) {
+    await run();
+}

--- a/services/hyperliquid/info.test.ts
+++ b/services/hyperliquid/info.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import {
+    fetchSpotMeta,
+    type HyperliquidSpotMeta,
+    resolvePairNames,
+} from './info';
+
+describe('resolvePairNames', () => {
+    test('passes canonical pair name through unchanged', () => {
+        const meta: HyperliquidSpotMeta = {
+            tokens: [
+                {
+                    name: 'USDC',
+                    fullName: null,
+                    index: 0,
+                    tokenId: '0x00',
+                    szDecimals: 8,
+                    weiDecimals: 8,
+                    isCanonical: true,
+                    evmContract: null,
+                    deployerTradingFeeShare: '0.0',
+                },
+                {
+                    name: 'PURR',
+                    fullName: null,
+                    index: 1,
+                    tokenId: '0x01',
+                    szDecimals: 0,
+                    weiDecimals: 5,
+                    isCanonical: true,
+                    evmContract: null,
+                    deployerTradingFeeShare: '0.0',
+                },
+            ],
+            universe: [
+                {
+                    tokens: [1, 0],
+                    name: 'PURR/USDC',
+                    index: 0,
+                    isCanonical: true,
+                },
+            ],
+        };
+        expect(resolvePairNames(meta)).toEqual([
+            { spot_coin: 'PURR/USDC', pair_name: 'PURR/USDC' },
+        ]);
+    });
+
+    test('resolves @N pair name from token indexes', () => {
+        const meta: HyperliquidSpotMeta = {
+            tokens: [
+                {
+                    name: 'USDC',
+                    fullName: null,
+                    index: 0,
+                    tokenId: '0x00',
+                    szDecimals: 8,
+                    weiDecimals: 8,
+                    isCanonical: true,
+                    evmContract: null,
+                    deployerTradingFeeShare: '0.0',
+                },
+                {
+                    name: 'HYPE',
+                    fullName: 'Hyperliquid',
+                    index: 150,
+                    tokenId: '0x96',
+                    szDecimals: 2,
+                    weiDecimals: 8,
+                    isCanonical: false,
+                    evmContract: null,
+                    deployerTradingFeeShare: '0.0',
+                },
+            ],
+            universe: [
+                {
+                    tokens: [150, 0],
+                    name: '@107',
+                    index: 107,
+                    isCanonical: false,
+                },
+            ],
+        };
+        expect(resolvePairNames(meta)).toEqual([
+            { spot_coin: '@107', pair_name: 'HYPE/USDC' },
+        ]);
+    });
+
+    test('skips @N pairs that reference unknown token indexes', () => {
+        const meta: HyperliquidSpotMeta = {
+            tokens: [],
+            universe: [
+                {
+                    tokens: [150, 0],
+                    name: '@107',
+                    index: 107,
+                    isCanonical: false,
+                },
+            ],
+        };
+        expect(resolvePairNames(meta)).toEqual([]);
+    });
+
+    test('processes mixed canonical and auction-deployed pairs', () => {
+        const meta: HyperliquidSpotMeta = {
+            tokens: [
+                {
+                    name: 'USDC',
+                    fullName: null,
+                    index: 0,
+                    tokenId: '0x00',
+                    szDecimals: 8,
+                    weiDecimals: 8,
+                    isCanonical: true,
+                    evmContract: null,
+                    deployerTradingFeeShare: '0.0',
+                },
+                {
+                    name: 'PURR',
+                    fullName: null,
+                    index: 1,
+                    tokenId: '0x01',
+                    szDecimals: 0,
+                    weiDecimals: 5,
+                    isCanonical: true,
+                    evmContract: null,
+                    deployerTradingFeeShare: '0.0',
+                },
+                {
+                    name: 'HYPE',
+                    fullName: null,
+                    index: 150,
+                    tokenId: '0x96',
+                    szDecimals: 2,
+                    weiDecimals: 8,
+                    isCanonical: false,
+                    evmContract: null,
+                    deployerTradingFeeShare: '0.0',
+                },
+            ],
+            universe: [
+                {
+                    tokens: [1, 0],
+                    name: 'PURR/USDC',
+                    index: 0,
+                    isCanonical: true,
+                },
+                {
+                    tokens: [150, 0],
+                    name: '@107',
+                    index: 107,
+                    isCanonical: false,
+                },
+            ],
+        };
+        expect(resolvePairNames(meta)).toEqual([
+            { spot_coin: 'PURR/USDC', pair_name: 'PURR/USDC' },
+            { spot_coin: '@107', pair_name: 'HYPE/USDC' },
+        ]);
+    });
+});
+
+describe('fetchSpotMeta', () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    test('parses a well-formed spotMeta response', async () => {
+        const body: HyperliquidSpotMeta = {
+            tokens: [
+                {
+                    name: 'USDC',
+                    fullName: null,
+                    index: 0,
+                    tokenId: '0x00',
+                    szDecimals: 8,
+                    weiDecimals: 8,
+                    isCanonical: true,
+                    evmContract: null,
+                    deployerTradingFeeShare: '0.0',
+                },
+            ],
+            universe: [],
+        };
+        globalThis.fetch = mock(() =>
+            Promise.resolve(
+                new Response(JSON.stringify(body), { status: 200 }),
+            ),
+        ) as unknown as typeof fetch;
+        const got = await fetchSpotMeta('http://example/info');
+        expect(got).toEqual(body);
+    });
+
+    test('throws on non-2xx response', async () => {
+        globalThis.fetch = mock(() =>
+            Promise.resolve(new Response('nope', { status: 500 })),
+        ) as unknown as typeof fetch;
+        await expect(fetchSpotMeta('http://example/info')).rejects.toThrow(
+            /HTTP 500/,
+        );
+    });
+
+    test('throws when response is missing tokens or universe', async () => {
+        globalThis.fetch = mock(() =>
+            Promise.resolve(new Response('{}', { status: 200 })),
+        ) as unknown as typeof fetch;
+        await expect(fetchSpotMeta('http://example/info')).rejects.toThrow(
+            /missing tokens\/universe/,
+        );
+    });
+});

--- a/services/hyperliquid/info.ts
+++ b/services/hyperliquid/info.ts
@@ -1,0 +1,134 @@
+import { createLogger } from '../../lib/logger';
+
+/**
+ * Per-request timeout for Hyperliquid Info API calls. Without this, a stalled
+ * TCP connection can hang the run loop indefinitely.
+ */
+const FETCH_TIMEOUT_MS = parseInt(
+    process.env.HYPERLIQUID_FETCH_TIMEOUT_MS || '30000',
+    10,
+);
+
+const log = createLogger('hyperliquid');
+
+/**
+ * Token entry returned by `spotMeta`. `tokens[].index` matches the indexes
+ * referenced in `universe[].tokens`. `evmContract` is null for tokens that
+ * don't have a HyperEVM mirror.
+ */
+export interface HyperliquidSpotToken {
+    name: string;
+    fullName: string | null;
+    index: number;
+    tokenId: string;
+    szDecimals: number;
+    weiDecimals: number;
+    isCanonical: boolean;
+    evmContract: {
+        address: string;
+        evm_extra_wei_decimals: number;
+    } | null;
+    deployerTradingFeeShare: string;
+}
+
+/**
+ * Universe entry returned by `spotMeta`. `tokens` is `[base_index, quote_index]`
+ * referencing `tokens[].index`. `name` is `@N` for auction-deployed pairs (where
+ * N matches `index`) or a canonical human form like `PURR/USDC`.
+ */
+export interface HyperliquidSpotPair {
+    tokens: [number, number];
+    name: string;
+    index: number;
+    isCanonical: boolean;
+}
+
+export interface HyperliquidSpotMeta {
+    tokens: HyperliquidSpotToken[];
+    universe: HyperliquidSpotPair[];
+}
+
+export interface SpotPairNameRow {
+    spot_coin: string;
+    pair_name: string;
+}
+
+/**
+ * POST `{type: spotMeta}` to the Hyperliquid Info API. Returns the parsed
+ * response body. The Info API mirrors the public REST shape on
+ * `https://api.hyperliquid.xyz/info`; any URL pointing at a compatible
+ * `--serve-info` reader works equivalently.
+ */
+export async function fetchSpotMeta(
+    infoUrl: string,
+): Promise<HyperliquidSpotMeta> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    try {
+        const response = await fetch(infoUrl, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ type: 'spotMeta' }),
+            signal: controller.signal,
+        });
+
+        if (!response.ok) {
+            throw new Error(
+                `Hyperliquid /info returned HTTP ${response.status}`,
+            );
+        }
+
+        const body = (await response.json()) as HyperliquidSpotMeta;
+
+        if (!Array.isArray(body.tokens) || !Array.isArray(body.universe)) {
+            throw new Error(
+                'Hyperliquid /info spotMeta response missing tokens/universe arrays',
+            );
+        }
+
+        return body;
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+/**
+ * Resolve `@N` pair names into `BASE/QUOTE` strings using the token table.
+ * Canonical pairs (`PURR/USDC`) come through with their human name already set
+ * — those pass through unchanged. Auction-deployed pairs (`@107`) get joined
+ * against the token index to produce `HYPE/USDC`.
+ *
+ * The `spot_coin` column is the value substreams writes into `coin` on fills,
+ * so Token API can JOIN directly: `LEFT JOIN state_spot_pair_names AS n FINAL
+ * ON n.spot_coin = coin`.
+ */
+export function resolvePairNames(meta: HyperliquidSpotMeta): SpotPairNameRow[] {
+    const tokensByIndex = new Map<number, HyperliquidSpotToken>();
+    for (const token of meta.tokens) {
+        tokensByIndex.set(token.index, token);
+    }
+
+    const rows: SpotPairNameRow[] = [];
+    for (const pair of meta.universe) {
+        if (pair.name.startsWith('@')) {
+            const [baseIdx, quoteIdx] = pair.tokens;
+            const base = tokensByIndex.get(baseIdx);
+            const quote = tokensByIndex.get(quoteIdx);
+            if (!base || !quote) {
+                log.warn('Spot pair references unknown token index', {
+                    pair,
+                });
+                continue;
+            }
+            rows.push({
+                spot_coin: pair.name,
+                pair_name: `${base.name}/${quote.name}`,
+            });
+        } else {
+            // canonical pair — name already in BASE/QUOTE form
+            rows.push({ spot_coin: pair.name, pair_name: pair.name });
+        }
+    }
+    return rows;
+}

--- a/sql.schemas/schema.hyperliquid.sql
+++ b/sql.schemas/schema.hyperliquid.sql
@@ -1,0 +1,17 @@
+-- Hyperliquid spot pair names — `@N` → `BASE/QUOTE` lookup.
+--
+-- Populated by the `hyperliquid` scraper service polling the Hyperliquid Info
+-- API (`POST /info {type: spotMeta}`). Each poll writes a full snapshot with a
+-- fresh `refresh_time`; ReplacingMergeTree keeps only the latest version per
+-- `spot_coin`.
+--
+-- Token API joins this on `coin = spot_coin` to expose an additive
+-- `spot_pair_name` field on routes where spot fills appear.
+CREATE TABLE IF NOT EXISTS state_spot_pair_names (
+    spot_coin     LowCardinality(String) COMMENT 'value of `coin` on spot fills (e.g. `@107` or `PURR/USDC`)',
+    pair_name     LowCardinality(String) COMMENT 'resolved human pair name (e.g. `HYPE/USDC`)',
+    refresh_time  DateTime('UTC')        COMMENT 'snapshot time for this row'
+)
+ENGINE = ReplacingMergeTree(refresh_time)
+ORDER BY (spot_coin)
+COMMENT 'Hyperliquid spot pair name lookup populated by token-api-scraper';


### PR DESCRIPTION
## Summary
- Polls the Hyperliquid Info API `spotMeta` endpoint and snapshots resolved spot pair names into a new `state_spot_pair_names` table (ReplacingMergeTree keyed on `spot_coin`).
- Powers an additive `spot_pair_name` field on Token API routes that surface spot fills (e.g. resolves `@107` → `HYPE/USDC`).
- Wires `hyperliquid` into both the `run` and `setup` CLIs.

## Configuration
- `HYPERLIQUID_INFO_URL` — required; URL of a Hyperliquid Info API. The public endpoint is `https://api.hyperliquid.xyz/info`; deployments may also point this at a compatible `/info` reader.
- `HYPERLIQUID_FETCH_TIMEOUT_MS` — optional (default 30000).
- `CLICKHOUSE_DATABASE_INSERT` — should target the database where Token API queries spot fills.
- `AUTO_RESTART_DELAY` — recommend 300+ seconds (spot listings change slowly; minutes-to-hours latency is fine).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)