### PR TITLE
refactor(hyperliquid): align column names with fills + add token discovery + Copilot fixes

### DIFF
--- a/services/hyperliquid/index.test.ts
+++ b/services/hyperliquid/index.test.ts
@@ -86,8 +86,7 @@ describe('hyperliquid run()', () => {
 
     test('throws when HYPERLIQUID_INFO_URL is unset', async () => {
         delete process.env.HYPERLIQUID_INFO_URL;
-        // Re-import after env change so the module-level constant is re-read.
-        const { run } = await import(`./index?nocache=${Date.now()}`);
+        const { run } = await import('./index');
         await expect(run()).rejects.toThrow(/HYPERLIQUID_INFO_URL/);
     });
 
@@ -99,7 +98,7 @@ describe('hyperliquid run()', () => {
             ),
         ) as unknown as typeof fetch;
 
-        const { run } = await import(`./index?nocache=${Date.now()}`);
+        const { run } = await import('./index');
         await run();
 
         expect(mockInsert).toHaveBeenCalledTimes(1);
@@ -122,7 +121,7 @@ describe('hyperliquid run()', () => {
         expect(arg.values[0]!.base_token).toBe('HYPE');
         expect(arg.values[0]!.quote_token).toBe('USDC');
         expect(arg.values[0]!.refresh_time).toMatch(
-            /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
+            /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}$/,
         );
         expect(mockIncrementSuccess).toHaveBeenCalledTimes(1);
         expect(mockIncrementError).not.toHaveBeenCalled();
@@ -134,7 +133,7 @@ describe('hyperliquid run()', () => {
             Promise.resolve(new Response('boom', { status: 502 })),
         ) as unknown as typeof fetch;
 
-        const { run } = await import(`./index?nocache=${Date.now()}`);
+        const { run } = await import('./index');
         await expect(run()).rejects.toThrow();
         expect(mockIncrementError).toHaveBeenCalledTimes(1);
         expect(mockInsert).not.toHaveBeenCalled();

--- a/services/hyperliquid/index.test.ts
+++ b/services/hyperliquid/index.test.ts
@@ -106,8 +106,10 @@ describe('hyperliquid run()', () => {
         const arg = mockInsert.mock.calls[0]![0] as {
             table: string;
             values: Array<{
-                spot_coin: string;
-                pair_name: string;
+                coin: string;
+                market_name: string;
+                base_token: string;
+                quote_token: string;
                 refresh_time: string;
             }>;
             format: string;
@@ -115,8 +117,10 @@ describe('hyperliquid run()', () => {
         expect(arg.table).toBe('state_spot_pair_names');
         expect(arg.format).toBe('JSONEachRow');
         expect(arg.values).toHaveLength(1);
-        expect(arg.values[0]!.spot_coin).toBe('@107');
-        expect(arg.values[0]!.pair_name).toBe('HYPE/USDC');
+        expect(arg.values[0]!.coin).toBe('@107');
+        expect(arg.values[0]!.market_name).toBe('HYPE/USDC');
+        expect(arg.values[0]!.base_token).toBe('HYPE');
+        expect(arg.values[0]!.quote_token).toBe('USDC');
         expect(arg.values[0]!.refresh_time).toMatch(
             /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/,
         );

--- a/services/hyperliquid/index.ts
+++ b/services/hyperliquid/index.ts
@@ -14,10 +14,11 @@ const log = createLogger(serviceName);
 const INFO_URL = process.env.HYPERLIQUID_INFO_URL;
 
 /**
- * Fetch the latest spot universe + tokens, resolve `@N` pair names, and
- * snapshot all rows into `state_spot_pair_names` with a fresh `refresh_time`.
- * The CLI runner loops with `AUTO_RESTART_DELAY` between iterations, so a
- * single `run()` invocation maps to one poll cycle.
+ * Fetch the latest spot universe + tokens, resolve `@N` pair names into their
+ * `BASE/QUOTE` market names with split base/quote token symbols, and snapshot
+ * all rows into `state_spot_pair_names` with a fresh `refresh_time`. The CLI
+ * runner loops with `AUTO_RESTART_DELAY` between iterations, so a single
+ * `run()` invocation maps to one poll cycle.
  */
 export async function run(): Promise<void> {
     initService({ serviceName });

--- a/services/hyperliquid/index.ts
+++ b/services/hyperliquid/index.ts
@@ -11,8 +11,6 @@ import {
 const serviceName = 'hyperliquid';
 const log = createLogger(serviceName);
 
-const INFO_URL = process.env.HYPERLIQUID_INFO_URL;
-
 /**
  * Fetch the latest spot universe + tokens, resolve `@N` pair names into their
  * `BASE/QUOTE` market names with split base/quote token symbols, and snapshot
@@ -23,7 +21,8 @@ const INFO_URL = process.env.HYPERLIQUID_INFO_URL;
 export async function run(): Promise<void> {
     initService({ serviceName });
 
-    if (!INFO_URL) {
+    const infoUrl = process.env.HYPERLIQUID_INFO_URL;
+    if (!infoUrl) {
         throw new Error(
             'HYPERLIQUID_INFO_URL is required (set to a Hyperliquid /info endpoint)',
         );
@@ -34,7 +33,7 @@ export async function run(): Promise<void> {
 
     let meta: HyperliquidSpotMeta;
     try {
-        meta = await fetchSpotMeta(INFO_URL);
+        meta = await fetchSpotMeta(infoUrl);
     } catch (error) {
         log.error('Failed to fetch spot metadata', { error });
         incrementError(serviceName);
@@ -56,11 +55,12 @@ export async function run(): Promise<void> {
         return;
     }
 
-    // ClickHouse DateTime('UTC') rejects the trailing `Z` and fractional
-    // seconds that toISOString() emits, so trim both.
+    // ClickHouse DateTime64(3, 'UTC') rejects the trailing `Z`, so trim it
+    // but keep the millisecond precision so closely-spaced polls produce
+    // distinct `refresh_time` values (deterministic RMT merges).
     const refresh_time = new Date()
         .toISOString()
-        .slice(0, 19)
+        .slice(0, 23)
         .replace('T', ' ');
     const values = rows.map((r) => ({ ...r, refresh_time }));
 

--- a/services/hyperliquid/info.test.ts
+++ b/services/hyperliquid/info.test.ts
@@ -42,7 +42,12 @@ describe('resolvePairNames', () => {
             ],
         };
         expect(resolvePairNames(meta)).toEqual([
-            { spot_coin: 'PURR/USDC', pair_name: 'PURR/USDC' },
+            {
+                coin: 'PURR/USDC',
+                market_name: 'PURR/USDC',
+                base_token: 'PURR',
+                quote_token: 'USDC',
+            },
         ]);
     });
 
@@ -82,7 +87,12 @@ describe('resolvePairNames', () => {
             ],
         };
         expect(resolvePairNames(meta)).toEqual([
-            { spot_coin: '@107', pair_name: 'HYPE/USDC' },
+            {
+                coin: '@107',
+                market_name: 'HYPE/USDC',
+                base_token: 'HYPE',
+                quote_token: 'USDC',
+            },
         ]);
     });
 
@@ -154,8 +164,18 @@ describe('resolvePairNames', () => {
             ],
         };
         expect(resolvePairNames(meta)).toEqual([
-            { spot_coin: 'PURR/USDC', pair_name: 'PURR/USDC' },
-            { spot_coin: '@107', pair_name: 'HYPE/USDC' },
+            {
+                coin: 'PURR/USDC',
+                market_name: 'PURR/USDC',
+                base_token: 'PURR',
+                quote_token: 'USDC',
+            },
+            {
+                coin: '@107',
+                market_name: 'HYPE/USDC',
+                base_token: 'HYPE',
+                quote_token: 'USDC',
+            },
         ]);
     });
 });

--- a/services/hyperliquid/info.ts
+++ b/services/hyperliquid/info.ts
@@ -2,12 +2,17 @@ import { createLogger } from '../../lib/logger';
 
 /**
  * Per-request timeout for Hyperliquid Info API calls. Without this, a stalled
- * TCP connection can hang the run loop indefinitely.
+ * TCP connection can hang the run loop indefinitely. Falls back to 30s if the
+ * env override is missing, non-numeric, or non-positive — guards against
+ * `parseInt('garbage')` ⇒ NaN ⇒ instant abort.
  */
-const FETCH_TIMEOUT_MS = parseInt(
-    process.env.HYPERLIQUID_FETCH_TIMEOUT_MS || '30000',
-    10,
-);
+const FETCH_TIMEOUT_MS = (() => {
+    const parsed = Number.parseInt(
+        process.env.HYPERLIQUID_FETCH_TIMEOUT_MS ?? '',
+        10,
+    );
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 30000;
+})();
 
 const log = createLogger('hyperliquid');
 

--- a/services/hyperliquid/info.ts
+++ b/services/hyperliquid/info.ts
@@ -49,8 +49,10 @@ export interface HyperliquidSpotMeta {
 }
 
 export interface SpotPairNameRow {
-    spot_coin: string;
-    pair_name: string;
+    coin: string;
+    market_name: string;
+    base_token: string;
+    quote_token: string;
 }
 
 /**
@@ -94,14 +96,15 @@ export async function fetchSpotMeta(
 }
 
 /**
- * Resolve `@N` pair names into `BASE/QUOTE` strings using the token table.
- * Canonical pairs (`PURR/USDC`) come through with their human name already set
- * — those pass through unchanged. Auction-deployed pairs (`@107`) get joined
- * against the token index to produce `HYPE/USDC`.
+ * Resolve `@N` pair names into `BASE/QUOTE` strings using the token table,
+ * and split out the base/quote token symbols for discovery filters.
  *
- * The `spot_coin` column is the value substreams writes into `coin` on fills,
- * so Token API can JOIN directly: `LEFT JOIN state_spot_pair_names AS n FINAL
- * ON n.spot_coin = coin`.
+ * Canonical pairs (`PURR/USDC`) come through with their human name already
+ * set — split on `/` to recover the token symbols. Auction-deployed pairs
+ * (`@107`) get joined against the token index to produce `HYPE/USDC`.
+ *
+ * The `coin` column matches the value substreams writes into `coin` on fills,
+ * so Token API can JOIN directly with `USING (coin)`.
  */
 export function resolvePairNames(meta: HyperliquidSpotMeta): SpotPairNameRow[] {
     const tokensByIndex = new Map<number, HyperliquidSpotToken>();
@@ -122,12 +125,22 @@ export function resolvePairNames(meta: HyperliquidSpotMeta): SpotPairNameRow[] {
                 continue;
             }
             rows.push({
-                spot_coin: pair.name,
-                pair_name: `${base.name}/${quote.name}`,
+                coin: pair.name,
+                market_name: `${base.name}/${quote.name}`,
+                base_token: base.name,
+                quote_token: quote.name,
             });
         } else {
-            // canonical pair — name already in BASE/QUOTE form
-            rows.push({ spot_coin: pair.name, pair_name: pair.name });
+            // Canonical pair — name already in BASE/QUOTE form. Split to
+            // recover the token symbols for discovery filters.
+            const [base_token = pair.name, quote_token = ''] =
+                pair.name.split('/');
+            rows.push({
+                coin: pair.name,
+                market_name: pair.name,
+                base_token,
+                quote_token,
+            });
         }
     }
     return rows;

--- a/sql.schemas/schema.hyperliquid.sql
+++ b/sql.schemas/schema.hyperliquid.sql
@@ -8,10 +8,12 @@
 -- Token API joins this on `coin = spot_coin` to expose an additive
 -- `spot_pair_name` field on routes where spot fills appear.
 CREATE TABLE IF NOT EXISTS state_spot_pair_names (
-    spot_coin     LowCardinality(String) COMMENT 'value of `coin` on spot fills (e.g. `@107` or `PURR/USDC`)',
-    pair_name     LowCardinality(String) COMMENT 'resolved human pair name (e.g. `HYPE/USDC`)',
+    coin          LowCardinality(String) COMMENT 'matches `coin` on spot fills (e.g. `@107` or `PURR/USDC`)',
+    market_name   LowCardinality(String) COMMENT 'resolved human market name (e.g. `HYPE/USDC`)',
+    base_token    LowCardinality(String) COMMENT 'base token symbol (e.g. `HYPE`)',
+    quote_token   LowCardinality(String) COMMENT 'quote token symbol (e.g. `USDC`)',
     refresh_time  DateTime('UTC')        COMMENT 'snapshot time for this row'
 )
 ENGINE = ReplacingMergeTree(refresh_time)
-ORDER BY (spot_coin)
+ORDER BY (coin)
 COMMENT 'Hyperliquid spot pair name lookup populated by token-api-scraper';

--- a/sql.schemas/schema.hyperliquid.sql
+++ b/sql.schemas/schema.hyperliquid.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS state_spot_pair_names (
     market_name   LowCardinality(String) COMMENT 'resolved human market name (e.g. `HYPE/USDC`)',
     base_token    LowCardinality(String) COMMENT 'base token symbol (e.g. `HYPE`)',
     quote_token   LowCardinality(String) COMMENT 'quote token symbol (e.g. `USDC`)',
-    refresh_time  DateTime('UTC')        COMMENT 'snapshot time for this row'
+    refresh_time  DateTime64(3, 'UTC')   COMMENT 'snapshot time for this row (ms precision so closely-spaced polls remain deterministic for ReplacingMergeTree merges)'
 )
 ENGINE = ReplacingMergeTree(refresh_time)
 ORDER BY (coin)


### PR DESCRIPTION
Follow-up to #294. Two commits:

## Schema rename + token split
Aligns column names with the substreams `fills` table and splits out base/quote token symbols so Token API can support discovery filters like `?base_token=HYPE` on `/markets`.

- Rename `spot_coin` → `coin` so JOINs against `fills`/`state_ohlcv_fills` can use `USING (coin)`.
- Rename `pair_name` → `market_name` to match the API surface (`Hyperliquid Markets` tag, `/markets/*` endpoints) — the column applies uniformly across spot, perps, and builder dexes.
- Add `base_token` and `quote_token` columns split from the resolved name, populating discovery filters.

The canonical `PURR/USDC` pair is still included in the table; its `coin` value matches `market_name` because HL uses the human pair name as the on-chain identifier for that one pre-HIP-1 pair, but `base_token`/`quote_token` still resolve to `PURR`/`USDC` so it shows up under `?base_token=PURR`.

## Copilot review fixes (from #294)
- Validate `HYPERLIQUID_FETCH_TIMEOUT_MS`: fall back to 30 s default when the env value is missing, non-numeric, or non-positive (previously `parseInt('garbage')` yielded `NaN`, causing the timeout to fire immediately).
- Switch `refresh_time` from `DateTime('UTC')` to `DateTime64(3, 'UTC')` with millisecond precision so closely-spaced polls produce distinct version values for ReplacingMergeTree merges.
- Read `HYPERLIQUID_INFO_URL` inside `run()` instead of at module-load time, so tests no longer need cache-busting `?nocache=...` imports.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)