### PR TITLE
feat(metadata): seed hyperevm native HYPE row

### DIFF
--- a/sql.schemas/schema.metadata_evm.sql
+++ b/sql.schemas/schema.metadata_evm.sql
@@ -32,7 +32,7 @@ ENGINE = ReplacingMergeTree(created_at)
 TTL created_at + INTERVAL 1 WEEK
 ORDER BY ( network, contract );
 
--- base,avalanche,unichain,tron,bsc,polygon,mainnet,arbitrum-one,optimism --
+-- base,avalanche,unichain,tron,bsc,polygon,mainnet,arbitrum-one,optimism,hyperevm --
 INSERT INTO metadata (network, contract, decimals, name, symbol) VALUES
     ('tron', 'T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb', 6, 'Tron', 'TRX'),
     ('tron', '0x0000000000000000000000000000000000000000', 6, 'Tron', 'TRX'),
@@ -43,4 +43,5 @@ INSERT INTO metadata (network, contract, decimals, name, symbol) VALUES
     ('optimism', '0x0000000000000000000000000000000000000000', 18, 'ETH', 'ETH'),
     ('arbitrum-one', '0x0000000000000000000000000000000000000000', 18, 'ETH', 'ETH'),
     ('unichain', '0x0000000000000000000000000000000000000000', 18, 'ETH', 'ETH'),
-    ('base', '0x0000000000000000000000000000000000000000', 18, 'ETH', 'ETH');
+    ('base', '0x0000000000000000000000000000000000000000', 18, 'ETH', 'ETH'),
+    ('hyperevm', '0x0000000000000000000000000000000000000000', 18, 'HYPE', 'HYPE');


### PR DESCRIPTION
## Summary

- Adds the zero-address (`0x0…0`) sentinel for `hyperevm` to `schema.metadata_evm.sql`, mirroring the existing rows for ETH/BNB/MATIC/AVAX/TRX.
- Without it, `/balances/native` and `/transfers/native` on hyperevm return `name=null, symbol=null` for the native row because the metadata join key has no match.

Closes #297

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)