### PR TITLE
feat(kalshi): add live tip-following scraper

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -45,6 +45,11 @@ const SERVICES = {
         description:
             'Fetch and store Hyperliquid spot pair name lookups from the Info API spotMeta endpoint',
     },
+    'kalshi-live': {
+        path: './services/kalshi/live.ts',
+        description:
+            'Tip-follow Kalshi Trade API v2 (trades / markets / events / series / candlesticks) into the kalshi.* tables',
+    },
     'metadata-solana-rpc': {
         path: './services/metadata-solana-rpc/index.ts',
         description:
@@ -85,6 +90,11 @@ const SETUP_ACTIONS = {
         files: ['./sql.schemas/schema.hyperliquid.sql'],
         description:
             'Deploy hyperliquid spot pair name lookup table (state_spot_pair_names)',
+    },
+    kalshi: {
+        files: ['./sql.schemas/schema.kalshi.sql'],
+        description:
+            'Deploy kalshi tables (series, events, markets, trades, candlesticks, cursor_state)',
     },
     'forked-blocks': {
         files: ['./sql.schemas/schema.blocks_forked.sql'],
@@ -382,6 +392,7 @@ Services:
   metadata-balances           ${SERVICES['metadata-balances'].description}
   polymarket                  ${SERVICES['polymarket'].description}
   hyperliquid                 ${SERVICES['hyperliquid'].description}
+  kalshi-live                 ${SERVICES['kalshi-live'].description}
   metadata-solana-rpc         ${SERVICES['metadata-solana-rpc'].description}
   metadata-solana-extras-rpc  ${SERVICES['metadata-solana-extras-rpc'].description}
   metadata-solana-clickhouse  ${SERVICES['metadata-solana-clickhouse'].description}
@@ -632,6 +643,38 @@ Example:
         await handleSetupCommand(files, options);
     });
 addClickhouseOptions(setupHyperliquid);
+
+// ---- setup kalshi ----
+const setupKalshi = setupCommand
+    .command('kalshi')
+    .description(SETUP_ACTIONS.kalshi.description)
+    .addHelpText(
+        'after',
+        `
+This command deploys the Kalshi prediction-market tables ingested by
+\`npm run cli run kalshi-live\` (scraper-managed, no substreams).
+
+Tables created:
+  - series         Kalshi recurring contract templates
+  - events         Real-world occurrences grouping one or more markets
+  - markets        Binary/scalar markets, latest state per ticker
+  - trades        Append-only trade fills (live + historical scrape target)
+  - candlesticks   Server-aggregated 1m/60m/1440m bars
+  - cursor_state   Per-scope cursor checkpoints for resumable polling
+
+Example:
+  $ npm run cli setup kalshi
+  $ npm run cli setup kalshi --cluster my_cluster
+`,
+    )
+    .action(async (options: any) => {
+        log.info('Setting up kalshi tables');
+        const files = SETUP_ACTIONS.kalshi.files.map((f) =>
+            resolve(__dirname, f),
+        );
+        await handleSetupCommand(files, options);
+    });
+addClickhouseOptions(setupKalshi);
 
 // ---- setup forked-blocks ----
 const setupForkedBlocks = setupCommand

--- a/lib/batch-insert.ts
+++ b/lib/batch-insert.ts
@@ -248,13 +248,20 @@ export function getBatchInsertQueue(): BatchInsertQueue {
 }
 
 /**
- * Shutdown the global batch insert queue
+ * Shutdown the global batch insert queue.
+ *
+ * Always nulls `globalBatchQueue` — even when the inner shutdown throws — so a
+ * subsequent `initBatchInsertQueue()` doesn't no-op against a half-dead queue
+ * whose periodic-flush timer is already cleared. The thrown error still
+ * propagates so callers see it.
  */
 export async function shutdownBatchInsertQueue(): Promise<void> {
-    if (globalBatchQueue) {
-        log.info('Shutting down batch insert queue');
+    if (!globalBatchQueue) return;
+    log.info('Shutting down batch insert queue');
+    try {
         await globalBatchQueue.shutdown();
         log.info('Batch insert queue shutdown complete');
+    } finally {
         globalBatchQueue = null;
     }
 }

--- a/lib/service-init.ts
+++ b/lib/service-init.ts
@@ -15,12 +15,23 @@ import { setLivenessSource } from './prometheus';
 
 const log = createLogger('service');
 
+// Track whether service has been initialized (for one-time logs)
+let serviceInitialized = false;
+
+/** Wall-clock heartbeat for services that legitimately have nothing to flush
+ * in a cycle (no new trades, no refresh due, drained backfill archives).
+ * The liveness probe ORs this with the batch queue's `lastSuccessfulFlushAt`
+ * so idle cycles don't trip the probe — but services must NOT bump this on
+ * cycles that errored, so silent insert failures still surface. */
+let lastServiceHeartbeat: number | undefined;
+
+export function markServiceAlive(): void {
+    lastServiceHeartbeat = Date.now();
+}
+
 export interface ServiceInitOptions {
     serviceName: string;
 }
-
-// Track whether service has been initialized (for one-time logs)
-let serviceInitialized = false;
 
 /**
  * Initialize common service configuration
@@ -36,13 +47,20 @@ export function initService(options: ServiceInitOptions): void {
 
     // Wire the liveness probe's progress signal without letting prometheus.ts
     // depend on batch-insert.ts (batch-insert already depends on prometheus
-    // for metrics, so a direct import would close the cycle).
+    // for metrics, so a direct import would close the cycle). Returns the
+    // most recent of the batch-queue flush stamp and the service heartbeat —
+    // services that do real writes report progress via the queue; idle
+    // services report via `markServiceAlive`.
     setLivenessSource(() => {
+        let queueAt: number | undefined;
         try {
-            return getBatchInsertQueue().getLastSuccessfulFlushAt();
+            queueAt = getBatchInsertQueue().getLastSuccessfulFlushAt();
         } catch {
-            return undefined;
+            queueAt = undefined;
         }
+        if (queueAt === undefined) return lastServiceHeartbeat;
+        if (lastServiceHeartbeat === undefined) return queueAt;
+        return Math.max(queueAt, lastServiceHeartbeat);
     });
 
     // Log startup info (always at INFO level)

--- a/services/kalshi/client.integration.test.ts
+++ b/services/kalshi/client.integration.test.ts
@@ -1,0 +1,91 @@
+// Integration tests against the live Kalshi Trade API. Gated by
+// `KALSHI_API_TESTS=1` — set this env var in release pipelines, leave unset
+// (default-off) in PR CI so contributors don't depend on Kalshi being up.
+
+import { describe, expect, test } from 'bun:test';
+import { KalshiClient } from './client';
+
+const RUN_INTEGRATION = !!process.env.KALSHI_API_TESTS;
+const d = RUN_INTEGRATION ? describe : describe.skip;
+
+d('KalshiClient against the live API', () => {
+    const c = new KalshiClient();
+
+    test('getHistoricalCutoff returns the three ts fields', async () => {
+        const cutoff = await c.getHistoricalCutoff();
+        expect(cutoff.trades_created_ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(cutoff.market_settled_ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(cutoff.orders_updated_ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    });
+
+    test('getTradesLive returns shape-compatible rows + cursor', async () => {
+        const page = await c.getTradesLive({ limit: 5 });
+        expect(Array.isArray(page.trades)).toBe(true);
+        expect(typeof page.cursor).toBe('string');
+        if (page.trades.length > 0) {
+            const t = page.trades[0];
+            expect(typeof t.trade_id).toBe('string');
+            expect(typeof t.ticker).toBe('string');
+            expect(t.created_time).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+            expect(typeof t.count_fp).toBe('string');
+            expect(typeof t.yes_price_dollars).toBe('string');
+            expect(['yes', 'no']).toContain(t.taker_outcome_side);
+            expect(['bid', 'ask']).toContain(t.taker_book_side);
+        }
+    });
+
+    test('getMarkets returns shape-compatible rows', async () => {
+        const page = await c.getMarkets({ limit: 3 });
+        expect(Array.isArray(page.markets)).toBe(true);
+        if (page.markets.length > 0) {
+            const m = page.markets[0];
+            expect(typeof m.ticker).toBe('string');
+            expect(['binary', 'scalar']).toContain(m.market_type);
+            // Status field uses stored vocab (active/closed/finalized/etc),
+            // not filter vocab (open/closed/settled).
+            expect(typeof m.status).toBe('string');
+        }
+    });
+
+    test('getEvents returns shape-compatible rows', async () => {
+        const page = await c.getEvents({ limit: 3 });
+        expect(Array.isArray(page.events)).toBe(true);
+        if (page.events.length > 0) {
+            const e = page.events[0];
+            expect(typeof e.event_ticker).toBe('string');
+            expect(typeof e.series_ticker).toBe('string');
+        }
+    });
+
+    // 15s timeout: ~14MB response + JSON parse can exceed Bun's 5s default.
+    test('getSeries returns the full catalogue in one shot', async () => {
+        const page = await c.getSeries();
+        // Universe has been ~10K+ since at least 2026-05.
+        expect(page.series.length).toBeGreaterThan(1000);
+        const s = page.series[0];
+        expect(typeof s.ticker).toBe('string');
+        expect(typeof s.title).toBe('string');
+        // fee_multiplier observed as both int and float across the corpus —
+        // either is acceptable but it MUST be a number when present.
+        if (s.fee_multiplier != null) {
+            expect(typeof s.fee_multiplier).toBe('number');
+        }
+    }, 15_000);
+
+    test('cursor pagination on /markets/trades advances forward', async () => {
+        const first = await c.getTradesLive({ limit: 100 });
+        if (!first.cursor || first.trades.length === 0) {
+            // No data window — skip.
+            return;
+        }
+        const second = await c.getTradesLive({
+            limit: 100,
+            cursor: first.cursor,
+        });
+        // Different page implies different trades; spot-check at least one
+        // trade_id differs across pages.
+        const firstIds = new Set(first.trades.map((t) => t.trade_id));
+        const overlap = second.trades.filter((t) => firstIds.has(t.trade_id));
+        expect(overlap.length).toBeLessThan(second.trades.length);
+    });
+});

--- a/services/kalshi/client.test.ts
+++ b/services/kalshi/client.test.ts
@@ -122,6 +122,33 @@ describe('KalshiClient.get', () => {
         expect(calls).toBe(2);
     });
 
+    test('retries on body-parse failure (200 OK with broken json mid-stream)', async () => {
+        let calls = 0;
+        installFetch(() => {
+            calls++;
+            const body =
+                calls < 2
+                    ? ({
+                          json: () =>
+                              Promise.reject(
+                                  new SyntaxError(
+                                      'Unexpected end of JSON input',
+                                  ),
+                              ),
+                          text: () => Promise.resolve(''),
+                          ok: true,
+                          status: 200,
+                      } as unknown as Response)
+                    : mockJson({ ok: 1 });
+            return Promise.resolve(body);
+        });
+        const out = await fastClient({ maxRetries: 3 }).get<{ ok: number }>(
+            '/test',
+        );
+        expect(out).toEqual({ ok: 1 });
+        expect(calls).toBe(2);
+    });
+
     test('does NOT retry on non-transient errors (TypeError, syntax errors, etc.)', async () => {
         let calls = 0;
         installFetch(() => {

--- a/services/kalshi/client.test.ts
+++ b/services/kalshi/client.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { KalshiClient } from './client';
+
+const originalFetch = globalThis.fetch;
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+function mockJson(body: unknown, status = 200): Response {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(JSON.stringify(body)),
+    } as unknown as Response;
+}
+
+/** Install a fetch mock for the current test; returns the mock for assertions. */
+function installFetch(
+    impl: (url: string) => Promise<Response>,
+): ReturnType<typeof mock> {
+    const m = mock(impl);
+    globalThis.fetch = m as unknown as typeof fetch;
+    return m;
+}
+
+const fastClient = (overrides: Record<string, unknown> = {}) =>
+    new KalshiClient({
+        baseDelayMs: 1,
+        maxDelayMs: 5,
+        requestTimeoutMs: 1000,
+        ...overrides,
+    });
+
+describe('KalshiClient.get', () => {
+    test('returns parsed JSON on first success', async () => {
+        const m = installFetch(() => Promise.resolve(mockJson({ ok: 1 })));
+        const out = await fastClient({ maxRetries: 0 }).get<{ ok: number }>(
+            '/test',
+        );
+        expect(out).toEqual({ ok: 1 });
+        expect(m).toHaveBeenCalledTimes(1);
+    });
+
+    test('retries on 429 with exponential backoff up to maxRetries', async () => {
+        let calls = 0;
+        installFetch(() => {
+            calls++;
+            return Promise.resolve(
+                calls < 3
+                    ? mockJson({ msg: 'rate-limited' }, 429)
+                    : mockJson({ ok: 1 }),
+            );
+        });
+        const out = await fastClient({ maxRetries: 5 }).get<{ ok: number }>(
+            '/test',
+        );
+        expect(out).toEqual({ ok: 1 });
+        expect(calls).toBe(3);
+    });
+
+    test('retries on 503 and other transient 5xx', async () => {
+        let calls = 0;
+        installFetch(() => {
+            calls++;
+            return Promise.resolve(
+                calls < 2
+                    ? mockJson({ msg: 'busy' }, 503)
+                    : mockJson({ ok: 1 }),
+            );
+        });
+        await fastClient({ maxRetries: 3 }).get('/test');
+        expect(calls).toBe(2);
+    });
+
+    test('does NOT retry on 400 bad request', async () => {
+        let calls = 0;
+        installFetch(() => {
+            calls++;
+            return Promise.resolve(mockJson({ msg: 'bad' }, 400));
+        });
+        await expect(
+            fastClient({ maxRetries: 5 }).get('/test'),
+        ).rejects.toThrow(/Kalshi 400 on GET \/test/);
+        expect(calls).toBe(1);
+    });
+
+    test('does NOT retry on 404', async () => {
+        let calls = 0;
+        installFetch(() => {
+            calls++;
+            return Promise.resolve(mockJson({ msg: 'nope' }, 404));
+        });
+        await expect(
+            fastClient({ maxRetries: 5 }).get('/test'),
+        ).rejects.toThrow(/Kalshi 404 on GET \/test/);
+        expect(calls).toBe(1);
+    });
+
+    test('gives up after maxRetries and surfaces the last response body', async () => {
+        const m = installFetch(() =>
+            Promise.resolve(mockJson({ msg: 'still busy' }, 503)),
+        );
+        await expect(
+            fastClient({ maxRetries: 2 }).get('/test'),
+        ).rejects.toThrow(/Kalshi 503/);
+        // attempts = maxRetries + 1 (initial + retries)
+        expect(m).toHaveBeenCalledTimes(3);
+    });
+
+    test('retries on transport errors (fetch failed)', async () => {
+        let calls = 0;
+        installFetch(() => {
+            calls++;
+            if (calls < 2) return Promise.reject(new Error('fetch failed'));
+            return Promise.resolve(mockJson({ ok: 1 }));
+        });
+        const out = await fastClient({ maxRetries: 3 }).get<{ ok: number }>(
+            '/test',
+        );
+        expect(out).toEqual({ ok: 1 });
+        expect(calls).toBe(2);
+    });
+
+    test('does NOT retry on non-transient errors (TypeError, syntax errors, etc.)', async () => {
+        let calls = 0;
+        installFetch(() => {
+            calls++;
+            return Promise.reject(new TypeError('unexpected token in JSON'));
+        });
+        await expect(
+            fastClient({ maxRetries: 5 }).get('/test'),
+        ).rejects.toThrow(/unexpected token/);
+        expect(calls).toBe(1);
+    });
+
+    test('drops undefined/empty params from the query string', async () => {
+        let captured: string | undefined;
+        installFetch((url) => {
+            captured = url;
+            return Promise.resolve(mockJson({ ok: 1 }));
+        });
+        await fastClient().get('/test', {
+            limit: 100,
+            ticker: '',
+            cursor: undefined,
+        });
+        expect(captured).toMatch(/limit=100/);
+        expect(captured).not.toMatch(/ticker=/);
+        expect(captured).not.toMatch(/cursor=/);
+    });
+});
+
+describe('per-endpoint defaults', () => {
+    test('getTradesLive defaults limit=1000', async () => {
+        let captured: string | undefined;
+        installFetch((url) => {
+            captured = url;
+            return Promise.resolve(mockJson({ trades: [], cursor: '' }));
+        });
+        await fastClient().getTradesLive();
+        expect(captured).toMatch(/\/markets\/trades\?limit=1000/);
+    });
+
+    test('getEvents defaults limit=200 (server max)', async () => {
+        let captured: string | undefined;
+        installFetch((url) => {
+            captured = url;
+            return Promise.resolve(mockJson({ events: [], cursor: '' }));
+        });
+        await fastClient().getEvents();
+        expect(captured).toMatch(/\/events\?limit=200/);
+    });
+
+    test('getBulkCandlesticks joins market_tickers with commas', async () => {
+        let captured: string | undefined;
+        installFetch((url) => {
+            captured = url;
+            return Promise.resolve(mockJson({ markets: [] }));
+        });
+        await fastClient().getBulkCandlesticks({
+            market_tickers: ['A', 'B', 'C'],
+            start_ts: 100,
+            end_ts: 200,
+            period_interval: 1,
+        });
+        expect(captured).toMatch(/market_tickers=A%2CB%2CC/);
+    });
+});

--- a/services/kalshi/client.ts
+++ b/services/kalshi/client.ts
@@ -28,8 +28,8 @@ const DEFAULTS: Required<ClientOptions> = {
     maxRetries: 5,
     baseDelayMs: DEFAULT_CONFIG.BASE_DELAY_MS,
     maxDelayMs: DEFAULT_CONFIG.MAX_DELAY_MS,
-    // The lib default (100ms) is tuned for EVM RPCs; HTTP REST needs longer.
-    requestTimeoutMs: 15_000,
+    // /series returns ~14MB; 30s leaves headroom for slow links + CDN warm-up.
+    requestTimeoutMs: 30_000,
 };
 
 // Mirrors lib/uri-fetch.ts isRetryable status set.
@@ -93,7 +93,27 @@ export class KalshiClient {
                 throw err;
             }
 
-            if (resp.ok) return (await resp.json()) as T;
+            if (resp.ok) {
+                try {
+                    return (await resp.json()) as T;
+                } catch (parseErr) {
+                    // 200 OK but body parse failed — typically truncation /
+                    // CDN flake mid-stream. Treat as transient; retry the
+                    // whole request so we get a fresh body.
+                    if (attempt >= this.opts.maxRetries) {
+                        throw new Error(
+                            `Kalshi 200 body parse failed on GET ${path}: ${String((parseErr as Error)?.message ?? parseErr)}`,
+                        );
+                    }
+                    await this.sleep(attempt);
+                    logger.warn('kalshi body-parse retry', {
+                        url,
+                        attempt,
+                        err: String((parseErr as Error)?.message ?? parseErr),
+                    });
+                    continue;
+                }
+            }
 
             const retryable = RETRYABLE_STATUSES.has(resp.status);
             if (!retryable || attempt >= this.opts.maxRetries) {

--- a/services/kalshi/client.ts
+++ b/services/kalshi/client.ts
@@ -1,0 +1,218 @@
+// Thin REST client for Kalshi Trade API v2. Public market-data endpoints only —
+// no auth, no signing.
+
+import { DEFAULT_CONFIG } from '../../lib/config';
+import { logger } from '../../lib/logger';
+import type {
+    BulkCandlesPage,
+    CandlesPage,
+    EventsPage,
+    HistoricalCutoff,
+    MarketsPage,
+    SeriesPage,
+    TradesPage,
+} from './types';
+
+export const KALSHI_BASE = 'https://api.elections.kalshi.com/trade-api/v2';
+
+export interface ClientOptions {
+    baseUrl?: string;
+    maxRetries?: number;
+    baseDelayMs?: number;
+    maxDelayMs?: number;
+    requestTimeoutMs?: number;
+}
+
+const DEFAULTS: Required<ClientOptions> = {
+    baseUrl: KALSHI_BASE,
+    maxRetries: 5,
+    baseDelayMs: DEFAULT_CONFIG.BASE_DELAY_MS,
+    maxDelayMs: DEFAULT_CONFIG.MAX_DELAY_MS,
+    // The lib default (100ms) is tuned for EVM RPCs; HTTP REST needs longer.
+    requestTimeoutMs: 15_000,
+};
+
+// Mirrors lib/uri-fetch.ts isRetryable status set.
+const RETRYABLE_STATUSES = new Set([
+    408, 425, 429, 499, 502, 503, 504, 522, 523, 524,
+]);
+const RETRYABLE_FETCH_ERRORS = [
+    'network',
+    'econnreset',
+    'etimedout',
+    'enotfound',
+    'socket hang up',
+    'socket connection was closed',
+    'operation was aborted',
+    'fetch failed',
+    'aborterror',
+];
+
+function isRetryableFetchError(err: unknown): boolean {
+    const msg = String((err as Error)?.message || err || '').toLowerCase();
+    return RETRYABLE_FETCH_ERRORS.some((s) => msg.includes(s));
+}
+
+export class KalshiClient {
+    private readonly opts: Required<ClientOptions>;
+
+    constructor(opts: ClientOptions = {}) {
+        this.opts = { ...DEFAULTS, ...opts };
+    }
+
+    async get<T>(
+        path: string,
+        params: Record<string, string | number | boolean | undefined> = {},
+    ): Promise<T> {
+        const qs = new URLSearchParams();
+        for (const [k, v] of Object.entries(params)) {
+            if (v == null || v === '') continue;
+            qs.set(k, String(v));
+        }
+        const url = `${this.opts.baseUrl}${path}${qs.toString() ? `?${qs}` : ''}`;
+
+        for (let attempt = 0; ; attempt++) {
+            let resp: Response;
+            try {
+                resp = await fetch(url, {
+                    signal: AbortSignal.timeout(this.opts.requestTimeoutMs),
+                });
+            } catch (err) {
+                if (
+                    isRetryableFetchError(err) &&
+                    attempt < this.opts.maxRetries
+                ) {
+                    await this.sleep(attempt);
+                    logger.warn('kalshi transport retry', {
+                        url,
+                        attempt,
+                        err: String((err as Error)?.message || err),
+                    });
+                    continue;
+                }
+                throw err;
+            }
+
+            if (resp.ok) return (await resp.json()) as T;
+
+            const retryable = RETRYABLE_STATUSES.has(resp.status);
+            if (!retryable || attempt >= this.opts.maxRetries) {
+                const body = await resp.text();
+                throw new Error(
+                    `Kalshi ${resp.status} on GET ${path}: ${body.slice(0, 240)}`,
+                );
+            }
+            await this.sleep(attempt);
+            logger.warn('kalshi retry', {
+                url,
+                status: resp.status,
+                attempt,
+            });
+        }
+    }
+
+    private sleep(attempt: number): Promise<void> {
+        const delay = Math.min(
+            this.opts.baseDelayMs * 2 ** attempt,
+            this.opts.maxDelayMs,
+        );
+        return new Promise((r) => setTimeout(r, delay));
+    }
+
+    getHistoricalCutoff(): Promise<HistoricalCutoff> {
+        return this.get('/historical/cutoff');
+    }
+
+    /** Live (within-cutoff) trades. */
+    getTradesLive(
+        params: {
+            ticker?: string;
+            min_ts?: number;
+            max_ts?: number;
+            limit?: number;
+            cursor?: string;
+        } = {},
+    ): Promise<TradesPage> {
+        return this.get('/markets/trades', { limit: 1000, ...params });
+    }
+
+    /** Archived (before-cutoff) trades. */
+    getTradesHistorical(
+        params: {
+            ticker?: string;
+            min_ts?: number;
+            max_ts?: number;
+            limit?: number;
+            cursor?: string;
+        } = {},
+    ): Promise<TradesPage> {
+        return this.get('/historical/trades', { limit: 1000, ...params });
+    }
+
+    getMarkets(
+        params: {
+            status?: 'unopened' | 'open' | 'paused' | 'closed' | 'settled';
+            event_ticker?: string;
+            series_ticker?: string;
+            tickers?: string;
+            min_close_ts?: number;
+            max_close_ts?: number;
+            min_updated_ts?: number;
+            limit?: number;
+            cursor?: string;
+        } = {},
+    ): Promise<MarketsPage> {
+        return this.get('/markets', { limit: 1000, ...params });
+    }
+
+    getEvents(
+        params: {
+            status?: 'unopened' | 'open' | 'closed' | 'settled';
+            series_ticker?: string;
+            min_close_ts?: number;
+            min_updated_ts?: number;
+            with_nested_markets?: boolean;
+            limit?: number;
+            cursor?: string;
+        } = {},
+    ): Promise<EventsPage> {
+        return this.get('/events', { limit: 200, ...params });
+    }
+
+    getSeries(): Promise<SeriesPage> {
+        return this.get('/series');
+    }
+
+    getCandlesticks(params: {
+        series_ticker: string;
+        market_ticker: string;
+        start_ts: number;
+        end_ts: number;
+        period_interval: 1 | 60 | 1440;
+    }): Promise<CandlesPage> {
+        const { series_ticker, market_ticker, ...rest } = params;
+        return this.get(
+            `/series/${series_ticker}/markets/${market_ticker}/candlesticks`,
+            rest,
+        );
+    }
+
+    /**
+     * Bulk candlesticks across up to 100 tickers per call, capped at 10K bars
+     * total. Comma-separated `market_tickers`. Response uses `market_ticker`
+     * (with prefix), distinct from the singular endpoint's `ticker`.
+     */
+    getBulkCandlesticks(params: {
+        market_tickers: string[];
+        start_ts: number;
+        end_ts: number;
+        period_interval: 1 | 60 | 1440;
+    }): Promise<BulkCandlesPage> {
+        return this.get('/markets/candlesticks', {
+            market_tickers: params.market_tickers.join(','),
+            start_ts: params.start_ts,
+            end_ts: params.end_ts,
+            period_interval: params.period_interval,
+        });
+    }
+}

--- a/services/kalshi/client.ts
+++ b/services/kalshi/client.ts
@@ -2,7 +2,7 @@
 // no auth, no signing.
 
 import { DEFAULT_CONFIG } from '../../lib/config';
-import { logger } from '../../lib/logger';
+import { createLogger } from '../../lib/logger';
 import type {
     BulkCandlesPage,
     CandlesPage,
@@ -12,6 +12,8 @@ import type {
     SeriesPage,
     TradesPage,
 } from './types';
+
+const log = createLogger('kalshi-client');
 
 export const KALSHI_BASE = 'https://api.elections.kalshi.com/trade-api/v2';
 
@@ -83,7 +85,7 @@ export class KalshiClient {
                     attempt < this.opts.maxRetries
                 ) {
                     await this.sleep(attempt);
-                    logger.warn('kalshi transport retry', {
+                    log.warn('kalshi transport retry', {
                         url,
                         attempt,
                         err: String((err as Error)?.message || err),
@@ -106,7 +108,7 @@ export class KalshiClient {
                         );
                     }
                     await this.sleep(attempt);
-                    logger.warn('kalshi body-parse retry', {
+                    log.warn('kalshi body-parse retry', {
                         url,
                         attempt,
                         err: String((parseErr as Error)?.message ?? parseErr),
@@ -123,7 +125,7 @@ export class KalshiClient {
                 );
             }
             await this.sleep(attempt);
-            logger.warn('kalshi retry', {
+            log.warn('kalshi retry', {
                 url,
                 status: resp.status,
                 attempt,

--- a/services/kalshi/cursor.integration.test.ts
+++ b/services/kalshi/cursor.integration.test.ts
@@ -1,0 +1,75 @@
+// Integration tests for cursor checkpoint round-trip against a real CH.
+// Gated by `KALSHI_API_TESTS=1` AND requires a running CH with the kalshi
+// schema applied (see `npm run cli setup kalshi`).
+
+import { describe, expect, test } from 'bun:test';
+import { client } from '../../lib/clickhouse';
+import { getCursor, getCursors, isDue, markRan, setCursor } from './cursor';
+
+const RUN_INTEGRATION = !!process.env.KALSHI_API_TESTS;
+const d = RUN_INTEGRATION ? describe : describe.skip;
+
+const SCOPE_PREFIX = `__test_cursor_${Date.now()}_`;
+const scope = (suffix: string) => `${SCOPE_PREFIX}${suffix}`;
+
+d('cursor checkpoint round-trip against CH', () => {
+    test('setCursor then getCursor recovers both ms + µs-ISO', async () => {
+        const s = scope('roundtrip');
+        const iso = '2026-06-01T17:00:00.123456Z';
+        await setCursor(s, 'cursor-abc', iso);
+        const got = await getCursor(s);
+        expect(got).not.toBeNull();
+        expect(got!.scope).toBe(s);
+        expect(got!.last_cursor).toBe('cursor-abc');
+        // µs precision survives the round-trip.
+        expect(got!.last_processed_ts_iso).toBe(iso);
+        // ms derivation strips the µs tail.
+        expect(got!.last_processed_ts_ms).toBe(Date.parse(iso));
+    });
+
+    test('getCursor returns null for unknown scope', async () => {
+        const got = await getCursor(scope('does-not-exist'));
+        expect(got).toBeNull();
+    });
+
+    test('getCursors fetches multiple scopes in one query', async () => {
+        const sA = scope('multi-a');
+        const sB = scope('multi-b');
+        await setCursor(sA, 'a', '2026-06-01T17:00:01.000000Z');
+        await setCursor(sB, 'b', '2026-06-01T17:00:02.000000Z');
+        const map = await getCursors([sA, sB, scope('multi-missing')]);
+        expect(map.has(sA)).toBe(true);
+        expect(map.has(sB)).toBe(true);
+        expect(map.has(scope('multi-missing'))).toBe(false);
+        expect(map.get(sA)!.last_cursor).toBe('a');
+        expect(map.get(sB)!.last_cursor).toBe('b');
+    });
+
+    test('markRan stamps current time with an empty cursor', async () => {
+        const s = scope('markRan');
+        const before = Date.now();
+        await markRan(s);
+        const got = await getCursor(s);
+        expect(got).not.toBeNull();
+        expect(got!.last_cursor).toBe('');
+        expect(got!.last_processed_ts_ms).toBeGreaterThanOrEqual(before);
+        expect(got!.last_processed_ts_ms).toBeLessThanOrEqual(Date.now());
+    });
+
+    test('isDue with a freshly-stamped scope returns false', async () => {
+        const s = scope('isDue-fresh');
+        await markRan(s);
+        const got = await getCursor(s);
+        expect(isDue(got!.last_processed_ts_ms, 60)).toBe(false);
+    });
+
+    // CH ALTER ... DELETE is async by default; mutations_sync=2 waits for the
+    // mutation to land before returning.
+    test('cleanup test scopes', async () => {
+        await client.command({
+            query: `ALTER TABLE cursor_state DELETE WHERE startsWith(scope, {prefix:String})`,
+            query_params: { prefix: SCOPE_PREFIX },
+            clickhouse_settings: { mutations_sync: 2 },
+        });
+    });
+});

--- a/services/kalshi/cursor.test.ts
+++ b/services/kalshi/cursor.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { isDue } from './cursor';
+
+describe('isDue', () => {
+    test('returns true when no prior run exists (lastMs undefined)', () => {
+        expect(isDue(undefined, 60)).toBe(true);
+    });
+
+    test('returns true when interval has elapsed', () => {
+        const tenMinAgo = Date.now() - 10 * 60 * 1000;
+        expect(isDue(tenMinAgo, 60)).toBe(true);
+    });
+
+    test('returns false when interval has not elapsed', () => {
+        const justNow = Date.now() - 1000;
+        expect(isDue(justNow, 60)).toBe(false);
+    });
+
+    test('returns true at exact interval boundary', () => {
+        const exactlyAtInterval = Date.now() - 60 * 1000;
+        // >= comparison: equal-or-greater is due.
+        expect(isDue(exactlyAtInterval, 60)).toBe(true);
+    });
+});

--- a/services/kalshi/cursor.ts
+++ b/services/kalshi/cursor.ts
@@ -1,0 +1,92 @@
+// Per-scope checkpoint persisted in `cursor_state`. Each row is keyed by an
+// opaque `scope` string. For data-walking passes (e.g. `trades_live`)
+// `last_processed_ts` is the high-watermark of the last row ingested. For
+// refresh passes (markets / events / series / candles) the same column doubles
+// as a clock — `last_processed_ts` is the time of the last successful run.
+
+import { insertClient, query } from '../../lib/clickhouse';
+
+export interface CursorCheckpoint {
+    scope: string;
+    last_cursor: string;
+    /** Unix ms (derived from `last_processed_ts`); precision-lossy for trade compares. */
+    last_processed_ts_ms: number;
+    /** Full µs-precision ISO 8601 string with trailing Z, e.g. `2026-06-01T17:00:00.123456Z`. */
+    last_processed_ts_iso: string;
+}
+
+interface CursorRow {
+    scope: string;
+    last_cursor: string;
+    last_processed_ts_ms: string | number;
+    /** CH returns `YYYY-MM-DDTHH:MM:SS.uuuuuu` (no Z). */
+    last_processed_ts_iso: string;
+}
+
+export async function getCursor(
+    scope: string,
+): Promise<CursorCheckpoint | null> {
+    const map = await getCursors([scope]);
+    return map.get(scope) ?? null;
+}
+
+/** Fetch multiple scopes in one CH round-trip; missing scopes are absent from the map. */
+export async function getCursors(
+    scopes: string[],
+): Promise<Map<string, CursorCheckpoint>> {
+    if (scopes.length === 0) return new Map();
+    const { data } = await query<CursorRow>(
+        `SELECT
+            scope,
+            last_cursor,
+            toUnixTimestamp64Milli(last_processed_ts) AS last_processed_ts_ms,
+            formatDateTime(last_processed_ts, '%Y-%m-%dT%H:%i:%S.%f', 'UTC') AS last_processed_ts_iso
+         FROM cursor_state
+         FINAL
+         WHERE scope IN ({scopes:Array(String)})`,
+        { scopes },
+    );
+    const map = new Map<string, CursorCheckpoint>();
+    for (const r of data) {
+        map.set(r.scope, {
+            scope: r.scope,
+            last_cursor: r.last_cursor,
+            last_processed_ts_ms: Number(r.last_processed_ts_ms),
+            last_processed_ts_iso: `${r.last_processed_ts_iso}Z`,
+        });
+    }
+    return map;
+}
+
+/**
+ * Persist a checkpoint. `last_processed_ts_iso` must be ISO 8601 — full µs
+ * precision recommended for data-walking passes so subsequent cycles can
+ * lex-compare against trade timestamps without losing the sub-ms fraction.
+ */
+export async function setCursor(
+    scope: string,
+    last_cursor: string,
+    last_processed_ts_iso: string,
+): Promise<void> {
+    // CH DateTime64('UTC') parses ISO 8601 with the trailing Z stripped.
+    const persisted = last_processed_ts_iso.replace(/Z$/, '');
+    await insertClient.insert({
+        table: 'cursor_state',
+        values: [{ scope, last_cursor, last_processed_ts: persisted }],
+        format: 'JSONEachRow',
+    });
+}
+
+/** True if `intervalSec` has elapsed since `lastMs` (or no prior run exists). */
+export function isDue(
+    lastMs: number | undefined,
+    intervalSec: number,
+): boolean {
+    if (lastMs == null) return true;
+    return Date.now() - lastMs >= intervalSec * 1000;
+}
+
+/** Stamp `scope` with `now`, empty cursor — for refresh-pass clocks. */
+export function markRan(scope: string): Promise<void> {
+    return setCursor(scope, '', new Date().toISOString());
+}

--- a/services/kalshi/live.test.ts
+++ b/services/kalshi/live.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { padIsoToMicroseconds } from './live';
+
+describe('padIsoToMicroseconds', () => {
+    test('pads ms-precision ISO to 6 fractional digits', () => {
+        const ms = Date.parse('2026-06-01T16:10:42.233Z');
+        expect(padIsoToMicroseconds(ms)).toBe('2026-06-01T16:10:42.233000Z');
+    });
+
+    test('lex-compares correctly against Kalshi µs-precision timestamps', () => {
+        // Pre-fix bug: `.233Z` lex-orders AFTER `.233435Z` because `'4' < 'Z'`.
+        // After padding, the same-ms bucket compares as we expect.
+        const ms = Date.parse('2026-06-01T16:10:42.233Z');
+        const watermark = padIsoToMicroseconds(ms);
+        expect('2026-06-01T16:10:42.233435Z' > watermark).toBe(true);
+        expect('2026-06-01T16:10:42.000000Z' < watermark).toBe(true);
+    });
+});

--- a/services/kalshi/live.ts
+++ b/services/kalshi/live.ts
@@ -147,6 +147,12 @@ async function wrap<T>(pass: string, fn: () => Promise<T>): Promise<T> {
     }
 }
 
+/** Unix ms → `YYYY-MM-DDTHH:MM:SS.NNNNNNZ` with the fractional seconds padded
+ * to 6 digits to match Kalshi's µs-precision trade timestamps. */
+export function padIsoToMicroseconds(ms: number): string {
+    return new Date(ms).toISOString().replace(/\.(\d{3})Z$/, '.$1000Z');
+}
+
 async function runTradesPass(
     client: KalshiClient,
     queue: Queue,
@@ -154,11 +160,13 @@ async function runTradesPass(
 ): Promise<void> {
     // Watermark for filter + comparison. Trade-side uses the full µs ISO from
     // the prior cursor so chronologically-newer trades that share the same ms
-    // bucket aren't dropped by a lexicographic prefix collision.
+    // bucket aren't dropped by a lexicographic prefix collision. Cold-start
+    // pads the ms-precision `Date#toISOString()` to 6 fractional digits — Kalshi
+    // emits `.NNNNNNZ` and `'4' < 'Z'`, so `.233Z` lex-orders AFTER `.233435Z`.
     const watermarkMs =
         prev?.last_processed_ts_ms ?? Date.now() - COLD_START_LOOKBACK_S * 1000;
     const watermarkIso =
-        prev?.last_processed_ts_iso ?? new Date(watermarkMs).toISOString();
+        prev?.last_processed_ts_iso ?? padIsoToMicroseconds(watermarkMs);
 
     let cursor: string | undefined;
     let prevCursor: string | undefined;
@@ -237,16 +245,29 @@ async function runRefreshPass<P, T>(
         : Math.floor(Date.now() / 1000) - opts.intervalSec;
 
     let cursor: string | undefined;
+    let prevCursor: string | undefined;
     let pages = 0;
     let inserted = 0;
     while (true) {
+        if (pages >= PAGE_HARD_LIMIT) {
+            throw new Error(
+                `${opts.label} refresh exceeded ${PAGE_HARD_LIMIT} pages — possible cursor loop`,
+            );
+        }
         const page = await opts.fetch(cursor, minUpdatedTs);
         for (const item of opts.items(page)) {
             await queue.add(opts.table, opts.mapper(item));
             inserted++;
         }
         pages++;
-        cursor = opts.nextCursor(page);
+        const nextCursor = opts.nextCursor(page);
+        if (nextCursor && nextCursor === prevCursor) {
+            throw new Error(
+                `${opts.label} refresh got the same cursor twice — server-side loop suspected`,
+            );
+        }
+        prevCursor = cursor;
+        cursor = nextCursor;
         if (!cursor) break;
     }
     log.info(`${opts.label} refresh`, { pages, inserted, minUpdatedTs });

--- a/services/kalshi/live.ts
+++ b/services/kalshi/live.ts
@@ -1,0 +1,349 @@
+// Kalshi live tip-following scraper. One `run()` call = one polling cycle;
+// the CLI runner loops with `AUTO_RESTART_DELAY` between iterations.
+
+import {
+    getBatchInsertQueue,
+    shutdownBatchInsertQueue,
+} from '../../lib/batch-insert';
+import { query } from '../../lib/clickhouse';
+import { createLogger } from '../../lib/logger';
+import { incrementError, incrementSuccess } from '../../lib/prometheus';
+import { initService } from '../../lib/service-init';
+import { KalshiClient } from './client';
+import {
+    type CursorCheckpoint,
+    getCursors,
+    isDue,
+    markRan,
+    setCursor,
+} from './cursor';
+import {
+    candleRow,
+    eventRow,
+    marketRow,
+    seriesRow,
+    tradeRow,
+} from './normalize';
+
+const serviceName = 'kalshi-live';
+const log = createLogger(serviceName);
+
+const SCOPE_TRADES = 'trades_live';
+const SCOPE_MARKETS = 'markets_refresh';
+const SCOPE_EVENTS = 'events_refresh';
+const SCOPE_SERIES = 'series_refresh';
+const SCOPE_CANDLES = 'candles_refresh';
+
+// Cold-start lookback: bounds the very first cycle when cursor_state is empty.
+// Steady-state runs drive `min_ts` from the persisted watermark instead.
+const COLD_START_LOOKBACK_S = 60;
+
+// Refresh-pass cadences. Each pass runs only if its scope clock is older than
+// these. The same value doubles as the cold-start lookback for `min_updated_ts`
+// so the very first refresh is roughly steady-state sized.
+const MARKETS_REFRESH_S = 5 * 60;
+const EVENTS_REFRESH_S = 10 * 60;
+const SERIES_REFRESH_S = 60 * 60;
+const CANDLES_REFRESH_S = 60;
+
+// Kalshi `/markets/candlesticks` caps at 100 tickers per call.
+const CANDLES_MAX_TICKERS = 100;
+// Window of trade activity used to pick "hot" tickers; matches the candles
+// refresh cadence so every tick that traded since the last pass is covered.
+const CANDLES_LOOKBACK_S = 60;
+
+// Defensive cap. With no MAX_PAGES_PER_CYCLE we drain to watermark every cycle,
+// but a server-side cursor bug (same cursor echoed twice) could spin forever.
+const PAGE_HARD_LIMIT = 10_000;
+
+type Queue = ReturnType<typeof getBatchInsertQueue>;
+
+export async function run(): Promise<void> {
+    initService({ serviceName });
+
+    const client = new KalshiClient();
+    const queue = getBatchInsertQueue();
+
+    try {
+        const cursors = await getCursors([
+            SCOPE_TRADES,
+            SCOPE_MARKETS,
+            SCOPE_EVENTS,
+            SCOPE_SERIES,
+            SCOPE_CANDLES,
+        ]);
+
+        await wrap('trades', () =>
+            runTradesPass(client, queue, cursors.get(SCOPE_TRADES)),
+        );
+
+        if (
+            isDue(
+                cursors.get(SCOPE_MARKETS)?.last_processed_ts_ms,
+                MARKETS_REFRESH_S,
+            )
+        ) {
+            await wrap('markets', async () => {
+                await runMarketsPass(client, queue, cursors.get(SCOPE_MARKETS));
+                await markRan(SCOPE_MARKETS);
+            });
+        }
+        if (
+            isDue(
+                cursors.get(SCOPE_EVENTS)?.last_processed_ts_ms,
+                EVENTS_REFRESH_S,
+            )
+        ) {
+            await wrap('events', async () => {
+                await runEventsPass(client, queue, cursors.get(SCOPE_EVENTS));
+                await markRan(SCOPE_EVENTS);
+            });
+        }
+        if (
+            isDue(
+                cursors.get(SCOPE_SERIES)?.last_processed_ts_ms,
+                SERIES_REFRESH_S,
+            )
+        ) {
+            await wrap('series', async () => {
+                await runSeriesPass(client, queue);
+                await markRan(SCOPE_SERIES);
+            });
+        }
+        if (
+            isDue(
+                cursors.get(SCOPE_CANDLES)?.last_processed_ts_ms,
+                CANDLES_REFRESH_S,
+            )
+        ) {
+            await wrap('candles', async () => {
+                await runCandlesPass(client, queue);
+                await markRan(SCOPE_CANDLES);
+            });
+        }
+
+        incrementSuccess(serviceName);
+    } catch (error) {
+        const err = error as Error & { pass?: string };
+        log.error('kalshi-live cycle failed', {
+            pass: err?.pass,
+            message: err?.message ?? String(error),
+            stack: err?.stack,
+        });
+        incrementError(serviceName);
+        throw error;
+    } finally {
+        await shutdownBatchInsertQueue();
+    }
+}
+
+/** Tag thrown errors with the pass name so the cycle catch can report which pass blew up. */
+async function wrap<T>(pass: string, fn: () => Promise<T>): Promise<T> {
+    try {
+        return await fn();
+    } catch (err) {
+        (err as Error & { pass?: string }).pass = pass;
+        throw err;
+    }
+}
+
+async function runTradesPass(
+    client: KalshiClient,
+    queue: Queue,
+    prev: CursorCheckpoint | undefined,
+): Promise<void> {
+    // Watermark for filter + comparison. Trade-side uses the full µs ISO from
+    // the prior cursor so chronologically-newer trades that share the same ms
+    // bucket aren't dropped by a lexicographic prefix collision.
+    const watermarkMs =
+        prev?.last_processed_ts_ms ?? Date.now() - COLD_START_LOOKBACK_S * 1000;
+    const watermarkIso =
+        prev?.last_processed_ts_iso ?? new Date(watermarkMs).toISOString();
+
+    let cursor: string | undefined;
+    let prevCursor: string | undefined;
+    let pages = 0;
+    let inserted = 0;
+    let newestSeen: string | undefined;
+    let crossedWatermark = false;
+
+    while (!crossedWatermark) {
+        if (pages >= PAGE_HARD_LIMIT) {
+            throw new Error(
+                `trades pass exceeded ${PAGE_HARD_LIMIT} pages — possible cursor loop`,
+            );
+        }
+        pages++;
+        const page = await client.getTradesLive({
+            min_ts: cursor ? undefined : Math.floor(watermarkMs / 1000),
+            cursor,
+            limit: 1000,
+        });
+
+        if (page.trades.length === 0) break;
+
+        for (const t of page.trades) {
+            if (t.created_time <= watermarkIso) {
+                crossedWatermark = true;
+                break;
+            }
+            await queue.add('trades', tradeRow(t));
+            inserted++;
+            if (!newestSeen || t.created_time > newestSeen) {
+                newestSeen = t.created_time;
+            }
+        }
+
+        const nextCursor = page.cursor || undefined;
+        if (nextCursor && nextCursor === prevCursor) {
+            throw new Error(
+                'trades pass got the same cursor twice — server-side loop suspected',
+            );
+        }
+        prevCursor = cursor;
+        cursor = nextCursor;
+        if (!cursor) break;
+    }
+
+    if (newestSeen) {
+        await setCursor(SCOPE_TRADES, cursor ?? '', newestSeen);
+    }
+
+    log.info('trades-live cycle', {
+        pages,
+        inserted,
+        hasMoreCursor: !!cursor,
+        newestSeen,
+    });
+}
+
+interface RefreshPassOpts<P, T> {
+    label: string;
+    intervalSec: number;
+    table: string;
+    fetch: (cursor: string | undefined, minUpdatedTs: number) => Promise<P>;
+    items: (page: P) => T[];
+    nextCursor: (page: P) => string | undefined;
+    mapper: (item: T) => Record<string, unknown>;
+}
+
+async function runRefreshPass<P, T>(
+    queue: Queue,
+    prev: CursorCheckpoint | undefined,
+    opts: RefreshPassOpts<P, T>,
+): Promise<void> {
+    const minUpdatedTs = prev
+        ? Math.floor(prev.last_processed_ts_ms / 1000)
+        : Math.floor(Date.now() / 1000) - opts.intervalSec;
+
+    let cursor: string | undefined;
+    let pages = 0;
+    let inserted = 0;
+    while (true) {
+        const page = await opts.fetch(cursor, minUpdatedTs);
+        for (const item of opts.items(page)) {
+            await queue.add(opts.table, opts.mapper(item));
+            inserted++;
+        }
+        pages++;
+        cursor = opts.nextCursor(page);
+        if (!cursor) break;
+    }
+    log.info(`${opts.label} refresh`, { pages, inserted, minUpdatedTs });
+}
+
+function runMarketsPass(
+    client: KalshiClient,
+    queue: Queue,
+    prev: CursorCheckpoint | undefined,
+): Promise<void> {
+    return runRefreshPass(queue, prev, {
+        label: 'markets',
+        intervalSec: MARKETS_REFRESH_S,
+        table: 'markets',
+        fetch: (cursor, minUpdatedTs) =>
+            client.getMarkets({
+                min_updated_ts: minUpdatedTs,
+                limit: 1000,
+                cursor,
+            }),
+        items: (p) => p.markets,
+        nextCursor: (p) => p.cursor || undefined,
+        mapper: marketRow,
+    });
+}
+
+function runEventsPass(
+    client: KalshiClient,
+    queue: Queue,
+    prev: CursorCheckpoint | undefined,
+): Promise<void> {
+    return runRefreshPass(queue, prev, {
+        label: 'events',
+        intervalSec: EVENTS_REFRESH_S,
+        table: 'events',
+        fetch: (cursor, minUpdatedTs) =>
+            client.getEvents({
+                min_updated_ts: minUpdatedTs,
+                limit: 200,
+                cursor,
+            }),
+        items: (p) => p.events,
+        nextCursor: (p) => p.cursor || undefined,
+        mapper: eventRow,
+    });
+}
+
+async function runSeriesPass(
+    client: KalshiClient,
+    queue: Queue,
+): Promise<void> {
+    const page = await client.getSeries();
+    for (const s of page.series) {
+        await queue.add('series', seriesRow(s));
+    }
+    log.info('series refresh', { inserted: page.series.length });
+}
+
+async function runCandlesPass(
+    client: KalshiClient,
+    queue: Queue,
+): Promise<void> {
+    const now = Math.floor(Date.now() / 1000);
+    const startTs = now - CANDLES_LOOKBACK_S;
+
+    const { data } = await query<{ ticker: string }>(
+        `SELECT ticker
+         FROM trades
+         WHERE created_time >= now() - INTERVAL {lookback:UInt32} SECOND
+         GROUP BY ticker
+         ORDER BY count() DESC
+         LIMIT {limit:UInt32}`,
+        { lookback: CANDLES_LOOKBACK_S, limit: CANDLES_MAX_TICKERS },
+    );
+    const tickers = data.map((r) => r.ticker);
+
+    if (tickers.length === 0) {
+        log.info('candles refresh', { tickers: 0, inserted: 0 });
+        return;
+    }
+
+    const page = await client.getBulkCandlesticks({
+        market_tickers: tickers,
+        start_ts: startTs,
+        end_ts: now,
+        period_interval: 1,
+    });
+
+    let inserted = 0;
+    for (const block of page.markets) {
+        for (const c of block.candlesticks) {
+            await queue.add(
+                'candlesticks',
+                candleRow(block.market_ticker, 1, c),
+            );
+            inserted++;
+        }
+    }
+    log.info('candles refresh', { tickers: tickers.length, inserted });
+}

--- a/services/kalshi/live.ts
+++ b/services/kalshi/live.ts
@@ -8,7 +8,7 @@ import {
 import { query } from '../../lib/clickhouse';
 import { createLogger } from '../../lib/logger';
 import { incrementError, incrementSuccess } from '../../lib/prometheus';
-import { initService } from '../../lib/service-init';
+import { initService, markServiceAlive } from '../../lib/service-init';
 import { KalshiClient } from './client';
 import {
     type CursorCheckpoint,
@@ -21,6 +21,7 @@ import {
     candleRow,
     eventRow,
     marketRow,
+    SENTINEL_TS_PREFIX,
     seriesRow,
     tradeRow,
 } from './normalize';
@@ -33,6 +34,12 @@ const SCOPE_MARKETS = 'markets_refresh';
 const SCOPE_EVENTS = 'events_refresh';
 const SCOPE_SERIES = 'series_refresh';
 const SCOPE_CANDLES = 'candles_refresh';
+
+/** Quarantine marker for a scope whose cursor pagination got stuck in a
+ * loop (server returned a cursor we already used). Subsequent cycles
+ * short-circuit on this value so the scope doesn't crashloop. Operator must
+ * clear the row to resume. */
+export const POISONED_SENTINEL = '__POISONED__';
 
 // Cold-start lookback: bounds the very first cycle when cursor_state is empty.
 // Steady-state runs drive `min_ts` from the persisted watermark instead.
@@ -64,6 +71,9 @@ export async function run(): Promise<void> {
     const client = new KalshiClient();
     const queue = getBatchInsertQueue();
 
+    let primaryError: unknown;
+    let cycleProgressed = false;
+
     try {
         const cursors = await getCursors([
             SCOPE_TRADES,
@@ -73,78 +83,150 @@ export async function run(): Promise<void> {
             SCOPE_CANDLES,
         ]);
 
-        await wrap('trades', () =>
-            runTradesPass(client, queue, cursors.get(SCOPE_TRADES)),
+        await runPass(
+            cursors,
+            'trades',
+            SCOPE_TRADES,
+            // Always due — trades pass tip-follows on every cycle.
+            true,
+            () => runTradesPass(client, queue, cursors.get(SCOPE_TRADES)),
         );
-
-        if (
+        await runPass(
+            cursors,
+            'markets',
+            SCOPE_MARKETS,
             isDue(
                 cursors.get(SCOPE_MARKETS)?.last_processed_ts_ms,
                 MARKETS_REFRESH_S,
-            )
-        ) {
-            await wrap('markets', async () => {
+            ),
+            async () => {
                 await runMarketsPass(client, queue, cursors.get(SCOPE_MARKETS));
-                await markRan(SCOPE_MARKETS);
-            });
-        }
-        if (
+                await flushAndMarkRan(queue, SCOPE_MARKETS, 'markets');
+            },
+        );
+        await runPass(
+            cursors,
+            'events',
+            SCOPE_EVENTS,
             isDue(
                 cursors.get(SCOPE_EVENTS)?.last_processed_ts_ms,
                 EVENTS_REFRESH_S,
-            )
-        ) {
-            await wrap('events', async () => {
+            ),
+            async () => {
                 await runEventsPass(client, queue, cursors.get(SCOPE_EVENTS));
-                await markRan(SCOPE_EVENTS);
-            });
-        }
-        if (
+                await flushAndMarkRan(queue, SCOPE_EVENTS, 'events');
+            },
+        );
+        await runPass(
+            cursors,
+            'series',
+            SCOPE_SERIES,
             isDue(
                 cursors.get(SCOPE_SERIES)?.last_processed_ts_ms,
                 SERIES_REFRESH_S,
-            )
-        ) {
-            await wrap('series', async () => {
+            ),
+            async () => {
                 await runSeriesPass(client, queue);
-                await markRan(SCOPE_SERIES);
-            });
-        }
-        if (
+                await flushAndMarkRan(queue, SCOPE_SERIES, 'series');
+            },
+        );
+        await runPass(
+            cursors,
+            'candles',
+            SCOPE_CANDLES,
             isDue(
                 cursors.get(SCOPE_CANDLES)?.last_processed_ts_ms,
                 CANDLES_REFRESH_S,
-            )
-        ) {
-            await wrap('candles', async () => {
+            ),
+            async () => {
                 await runCandlesPass(client, queue);
-                await markRan(SCOPE_CANDLES);
-            });
-        }
+                await flushAndMarkRan(queue, SCOPE_CANDLES, 'candles');
+            },
+        );
 
-        incrementSuccess(serviceName);
+        cycleProgressed = true;
     } catch (error) {
+        primaryError = error;
         const err = error as Error & { pass?: string };
         log.error('kalshi-live cycle failed', {
             pass: err?.pass,
             message: err?.message ?? String(error),
             stack: err?.stack,
         });
-        incrementError(serviceName);
-        throw error;
-    } finally {
+    }
+
+    // Shutdown runs on both paths to flush in-flight rows. If shutdown
+    // throws AND we already have a primary error, log+swallow so the
+    // original root cause survives propagation.
+    try {
         await shutdownBatchInsertQueue();
+    } catch (shutdownErr) {
+        if (primaryError) {
+            log.error('shutdown also failed; preserving original cycle error', {
+                shutdownErr: String(
+                    (shutdownErr as Error)?.message ?? shutdownErr,
+                ),
+            });
+        } else {
+            primaryError = shutdownErr;
+        }
+    }
+
+    if (primaryError) {
+        incrementError(serviceName);
+        throw primaryError;
+    }
+    // Heartbeat only on cycles that finished cleanly — error paths
+    // deliberately leave it stale so the liveness probe can catch silent
+    // insert failures + shutdown errors after the grace window.
+    if (cycleProgressed) {
+        markServiceAlive();
+    }
+    incrementSuccess(serviceName);
+}
+
+/** Run a single pass with quarantine + due-gate + per-pass error tagging.
+ * The quarantine check short-circuits if `cursor_state.<scope>.last_cursor`
+ * is `__POISONED__` — operator must clear the row to resume. */
+async function runPass(
+    cursors: Map<string, CursorCheckpoint>,
+    label: string,
+    scope: string,
+    due: boolean,
+    body: () => Promise<void>,
+): Promise<void> {
+    if (cursors.get(scope)?.last_cursor === POISONED_SENTINEL) {
+        log.warn(`${label} pass quarantined — manual intervention required`, {
+            scope,
+            oldest_seen: cursors.get(scope)?.last_processed_ts_iso,
+        });
+        return;
+    }
+    if (!due) return;
+    try {
+        await body();
+    } catch (err) {
+        (err as Error & { pass?: string }).pass = label;
+        throw err;
     }
 }
 
-/** Tag thrown errors with the pass name so the cycle catch can report which pass blew up. */
-async function wrap<T>(pass: string, fn: () => Promise<T>): Promise<T> {
-    try {
-        return await fn();
-    } catch (err) {
-        (err as Error & { pass?: string }).pass = pass;
-        throw err;
+/** Flush buffered rows, abort if any flush failed (or a prior periodic-timer
+ * flush left an unresolved error), then stamp the refresh-pass clock. The
+ * flush+check pair must precede `markRan` so the clock can't advance past
+ * rows that were lost mid-cycle. */
+async function flushAndMarkRan(
+    queue: Queue,
+    scope: string,
+    label: string,
+): Promise<void> {
+    const results = await queue.flushAll();
+    if (results.includes('err') || !queue.isHealthy()) {
+        throw new Error(
+            `${label} refresh: batch flush failed; clock not advanced`,
+        );
     }
+    await markRan(scope);
 }
 
 /** Unix ms → `YYYY-MM-DDTHH:MM:SS.NNNNNNZ` with the fractional seconds padded
@@ -168,6 +250,9 @@ async function runTradesPass(
     const watermarkIso =
         prev?.last_processed_ts_iso ?? padIsoToMicroseconds(watermarkMs);
 
+    // Local cursor only — live's resume mechanism is `min_ts` from the
+    // persisted watermark, not the persisted cursor token. The cursor is
+    // ephemeral for the duration of this cycle.
     let cursor: string | undefined;
     let prevCursor: string | undefined;
     let pages = 0;
@@ -191,6 +276,17 @@ async function runTradesPass(
         if (page.trades.length === 0) break;
 
         for (const t of page.trades) {
+            // Filter Kalshi's `0001-01-01...` sentinel BEFORE the watermark
+            // comparison — otherwise the sentinel lex-orders below any real
+            // watermark, falsely flips crossedWatermark, and the rest of the
+            // page is silently dropped.
+            if (t.created_time.startsWith(SENTINEL_TS_PREFIX)) {
+                log.warn('skipping trade with sentinel created_time', {
+                    trade_id: t.trade_id,
+                    ticker: t.ticker,
+                });
+                continue;
+            }
             if (t.created_time <= watermarkIso) {
                 crossedWatermark = true;
                 break;
@@ -203,9 +299,27 @@ async function runTradesPass(
         }
 
         const nextCursor = page.cursor || undefined;
-        if (nextCursor && nextCursor === prevCursor) {
+        // Detect both 1-hop self-loop (server echoes the cursor we just
+        // sent) and 2-hop alternation (A → B → A).
+        const isLoop =
+            !!nextCursor &&
+            (nextCursor === cursor || nextCursor === prevCursor);
+        if (isLoop) {
+            // Quarantine the looping scope. Flush first so already-queued
+            // rows reach CH; skip the quarantine persist if the flush itself
+            // failed so the next cycle can re-fetch and re-insert those rows.
+            const flushResults = await queue.flushAll();
+            const flushFailed =
+                flushResults.includes('err') || !queue.isHealthy();
+            if (!flushFailed) {
+                const watermark =
+                    newestSeen ?? padIsoToMicroseconds(Date.now());
+                await setCursor(SCOPE_TRADES, POISONED_SENTINEL, watermark);
+            }
             throw new Error(
-                'trades pass got the same cursor twice — server-side loop suspected',
+                flushFailed
+                    ? 'trades pass got a stale cursor back AND batch flush failed; cursor NOT quarantined to allow row recovery on retry'
+                    : 'trades pass got a stale cursor back — server-side loop suspected; cursor quarantined',
             );
         }
         prevCursor = cursor;
@@ -214,7 +328,18 @@ async function runTradesPass(
     }
 
     if (newestSeen) {
-        await setCursor(SCOPE_TRADES, cursor ?? '', newestSeen);
+        // Flush BEFORE advancing the watermark so the next cycle's `min_ts`
+        // never moves past rows that haven't landed in CH. Mirrors the
+        // refresh-pass guard via `flushAndMarkRan`.
+        const results = await queue.flushAll();
+        if (results.includes('err') || !queue.isHealthy()) {
+            throw new Error(
+                'trades pass: batch flush failed; watermark not advanced',
+            );
+        }
+        // `last_cursor` is unused on the read side (cycle-local), so persist
+        // an empty string and let `last_processed_ts` carry the resume signal.
+        await setCursor(SCOPE_TRADES, '', newestSeen);
     }
 
     log.info('trades-live cycle', {
@@ -227,12 +352,17 @@ async function runTradesPass(
 
 interface RefreshPassOpts<P, T> {
     label: string;
+    scope: string;
     intervalSec: number;
     table: string;
     fetch: (cursor: string | undefined, minUpdatedTs: number) => Promise<P>;
     items: (page: P) => T[];
     nextCursor: (page: P) => string | undefined;
     mapper: (item: T) => Record<string, unknown>;
+    /** Optional predicate: return a reason string to skip the item, or
+     * undefined to keep it. Used to drop entries whose sentinel timestamps
+     * would null-out into a non-nullable column on insert. */
+    skip?: (item: T) => string | undefined;
 }
 
 async function runRefreshPass<P, T>(
@@ -248,6 +378,7 @@ async function runRefreshPass<P, T>(
     let prevCursor: string | undefined;
     let pages = 0;
     let inserted = 0;
+    let skipped = 0;
     while (true) {
         if (pages >= PAGE_HARD_LIMIT) {
             throw new Error(
@@ -256,21 +387,49 @@ async function runRefreshPass<P, T>(
         }
         const page = await opts.fetch(cursor, minUpdatedTs);
         for (const item of opts.items(page)) {
+            const skipReason = opts.skip?.(item);
+            if (skipReason) {
+                log.warn(`skipping ${opts.label} item`, {
+                    reason: skipReason,
+                });
+                skipped++;
+                continue;
+            }
             await queue.add(opts.table, opts.mapper(item));
             inserted++;
         }
         pages++;
         const nextCursor = opts.nextCursor(page);
-        if (nextCursor && nextCursor === prevCursor) {
+        const isLoop =
+            !!nextCursor &&
+            (nextCursor === cursor || nextCursor === prevCursor);
+        if (isLoop) {
+            const flushResults = await queue.flushAll();
+            const flushFailed =
+                flushResults.includes('err') || !queue.isHealthy();
+            if (!flushFailed) {
+                await setCursor(
+                    opts.scope,
+                    POISONED_SENTINEL,
+                    padIsoToMicroseconds(Date.now()),
+                );
+            }
             throw new Error(
-                `${opts.label} refresh got the same cursor twice — server-side loop suspected`,
+                flushFailed
+                    ? `${opts.label} refresh got a stale cursor back AND batch flush failed; cursor NOT quarantined to allow row recovery on retry`
+                    : `${opts.label} refresh got a stale cursor back — server-side loop suspected; cursor quarantined`,
             );
         }
         prevCursor = cursor;
         cursor = nextCursor;
         if (!cursor) break;
     }
-    log.info(`${opts.label} refresh`, { pages, inserted, minUpdatedTs });
+    log.info(`${opts.label} refresh`, {
+        pages,
+        inserted,
+        skipped,
+        minUpdatedTs,
+    });
 }
 
 function runMarketsPass(
@@ -280,6 +439,7 @@ function runMarketsPass(
 ): Promise<void> {
     return runRefreshPass(queue, prev, {
         label: 'markets',
+        scope: SCOPE_MARKETS,
         intervalSec: MARKETS_REFRESH_S,
         table: 'markets',
         fetch: (cursor, minUpdatedTs) =>
@@ -291,6 +451,18 @@ function runMarketsPass(
         items: (p) => p.markets,
         nextCursor: (p) => p.cursor || undefined,
         mapper: marketRow,
+        // markets.created_time + markets.updated_time are non-nullable in CH.
+        // `ts()` would coerce the Kalshi sentinel to null and the batch insert
+        // would then fail; drop the row before it reaches the queue.
+        skip: (m) => {
+            if (m.created_time?.startsWith(SENTINEL_TS_PREFIX)) {
+                return 'sentinel created_time';
+            }
+            if (m.updated_time?.startsWith(SENTINEL_TS_PREFIX)) {
+                return 'sentinel updated_time';
+            }
+            return undefined;
+        },
     });
 }
 
@@ -301,6 +473,7 @@ function runEventsPass(
 ): Promise<void> {
     return runRefreshPass(queue, prev, {
         label: 'events',
+        scope: SCOPE_EVENTS,
         intervalSec: EVENTS_REFRESH_S,
         table: 'events',
         fetch: (cursor, minUpdatedTs) =>

--- a/services/kalshi/normalize.test.ts
+++ b/services/kalshi/normalize.test.ts
@@ -334,4 +334,17 @@ describe('candleRow', () => {
         expect(row.ticker).toBe('KXBTC15M-Y');
         expect(row.end_period_ts).toBe(1780329660);
     });
+
+    test('throws on unsupported period_interval (defensive runtime guard)', () => {
+        // Deliberately bypassing the PeriodInterval type to exercise the
+        // runtime guard against future codepaths that might widen the input.
+        const widened = candleRow as unknown as (
+            t: string,
+            p: number,
+            c: typeof CANDLE_FIXTURE,
+        ) => unknown;
+        expect(() => widened('X', 5, CANDLE_FIXTURE)).toThrow(
+            /unsupported period_interval 5/,
+        );
+    });
 });

--- a/services/kalshi/normalize.test.ts
+++ b/services/kalshi/normalize.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, test } from 'bun:test';
+import {
+    candleRow,
+    dec,
+    decOptional,
+    eventRow,
+    marketRow,
+    nullIfEmpty,
+    seriesRow,
+    tradeRow,
+    ts,
+} from './normalize';
+import type { Candlestick, EventEntity, Market, Series, Trade } from './types';
+
+describe('ts (sentinel + format coercion)', () => {
+    test('strips trailing Z', () => {
+        expect(ts('2026-06-01T17:00:00.123456Z')).toBe(
+            '2026-06-01T17:00:00.123456',
+        );
+    });
+
+    test('coerces the Kalshi 0001-01-01 sentinel to null', () => {
+        expect(ts('0001-01-01T00:00:00Z')).toBeNull();
+        expect(ts('0001-01-01T00:00:00.000000Z')).toBeNull();
+    });
+
+    test('handles missing input', () => {
+        expect(ts(undefined)).toBeNull();
+        expect(ts(null)).toBeNull();
+        expect(ts('')).toBeNull();
+    });
+
+    test('passes through non-Z-suffixed ISO strings unchanged', () => {
+        expect(ts('2026-06-01T17:00:00.123456')).toBe(
+            '2026-06-01T17:00:00.123456',
+        );
+    });
+});
+
+describe('nullIfEmpty', () => {
+    test('coerces empty string to null', () => {
+        expect(nullIfEmpty('')).toBeNull();
+    });
+
+    test('passes through non-empty', () => {
+        expect(nullIfEmpty('yes')).toBe('yes');
+        expect(nullIfEmpty('no')).toBe('no');
+    });
+
+    test('handles missing input', () => {
+        expect(nullIfEmpty(undefined)).toBeNull();
+        expect(nullIfEmpty(null)).toBeNull();
+    });
+});
+
+describe('dec', () => {
+    test('passes through decimal strings', () => {
+        expect(dec('0.0170')).toBe('0.0170');
+        expect(dec('14.00')).toBe('14.00');
+    });
+
+    test("defaults to '0' for missing input", () => {
+        expect(dec(undefined)).toBe('0');
+        expect(dec(null)).toBe('0');
+    });
+
+    test('keeps empty string (intentional: empty != missing for some callers)', () => {
+        // dec uses ?? — explicit empty string is preserved.
+        expect(dec('')).toBe('');
+    });
+});
+
+describe('decOptional', () => {
+    test('passes through decimal strings', () => {
+        expect(decOptional('1.234567')).toBe('1.234567');
+    });
+
+    test('coerces empty + missing to null', () => {
+        expect(decOptional('')).toBeNull();
+        expect(decOptional(undefined)).toBeNull();
+        expect(decOptional(null)).toBeNull();
+    });
+});
+
+// ----- row builders -----
+
+const TRADE_FIXTURE: Trade = {
+    trade_id: '3d3e898f-d385-41f5-b6d2-1ddc66a87076',
+    ticker: 'KXBTC15M-26JUN011215-15',
+    created_time: '2026-06-01T16:10:42.233435Z',
+    count_fp: '14.00',
+    yes_price_dollars: '0.0170',
+    no_price_dollars: '0.9830',
+    taker_outcome_side: 'yes',
+    taker_book_side: 'bid',
+};
+
+describe('tradeRow', () => {
+    test('strips Z from created_time', () => {
+        const row = tradeRow(TRADE_FIXTURE);
+        expect(row.created_time).toBe('2026-06-01T16:10:42.233435');
+    });
+
+    test('preserves decimal precision verbatim', () => {
+        const row = tradeRow(TRADE_FIXTURE);
+        expect(row.yes_price_dollars).toBe('0.0170');
+        expect(row.no_price_dollars).toBe('0.9830');
+        expect(row.count_fp).toBe('14.00');
+    });
+
+    test('preserves taker_outcome_side and taker_book_side as Enum labels', () => {
+        const row = tradeRow(TRADE_FIXTURE);
+        expect(row.taker_outcome_side).toBe('yes');
+        expect(row.taker_book_side).toBe('bid');
+    });
+});
+
+const MARKET_FIXTURE: Market = {
+    ticker: 'KXBTC15M-26JUN011215-15',
+    event_ticker: 'KXBTC15M-26JUN011215',
+    market_type: 'binary',
+    status: 'active',
+    title: 'BTC price up in next 15 mins?',
+    created_time: '2026-06-01T00:01:43.225007Z',
+    open_time: '2026-06-01T16:00:00Z',
+    close_time: '2026-06-01T16:15:00Z',
+    yes_bid_dollars: '0.0130',
+    yes_ask_dollars: '0.0170',
+    no_bid_dollars: '0.9830',
+    no_ask_dollars: '0.9870',
+    last_price_dollars: '0.0170',
+    updated_time: '2026-06-01T16:00:02.123147Z',
+    price_ranges: [
+        { start: '0.0000', end: '0.1000', step: '0.0010' },
+        { start: '0.1000', end: '0.9000', step: '0.0100' },
+        { start: '0.9000', end: '1.0000', step: '0.0010' },
+    ],
+    result: '',
+    expiration_value: '',
+};
+
+describe('marketRow', () => {
+    test('coerces empty result to null', () => {
+        expect(marketRow(MARKET_FIXTURE).result).toBeNull();
+    });
+
+    test('flattens price_ranges to parallel arrays', () => {
+        const row = marketRow(MARKET_FIXTURE);
+        expect(row.price_range_starts).toEqual(['0.0000', '0.1000', '0.9000']);
+        expect(row.price_range_ends).toEqual(['0.1000', '0.9000', '1.0000']);
+        expect(row.price_range_steps).toEqual(['0.0010', '0.0100', '0.0010']);
+    });
+
+    test('missing price_ranges produces empty arrays (not null)', () => {
+        const row = marketRow({ ...MARKET_FIXTURE, price_ranges: undefined });
+        expect(row.price_range_starts).toEqual([]);
+        expect(row.price_range_ends).toEqual([]);
+        expect(row.price_range_steps).toEqual([]);
+    });
+
+    test('preserves Kalshi-vocab status as-returned', () => {
+        // Kalshi filter values (`open`) and stored values (`active`) differ;
+        // we keep what Kalshi gives us and translate at the API layer.
+        expect(marketRow(MARKET_FIXTURE).status).toBe('active');
+        expect(
+            marketRow({ ...MARKET_FIXTURE, status: 'finalized' }).status,
+        ).toBe('finalized');
+    });
+
+    test('strips Z on every timestamp field', () => {
+        const row = marketRow(MARKET_FIXTURE);
+        expect(row.created_time).toBe('2026-06-01T00:01:43.225007');
+        expect(row.open_time).toBe('2026-06-01T16:00:00');
+        expect(row.close_time).toBe('2026-06-01T16:15:00');
+        expect(row.updated_time).toBe('2026-06-01T16:00:02.123147');
+    });
+});
+
+const EVENT_FIXTURE: EventEntity = {
+    event_ticker: 'KXBTC15M-26JUN011215',
+    series_ticker: 'KXBTC15M',
+    title: 'BTC 15 min',
+    sub_title: 'Jun 1 12:00-12:15 EDT',
+    mutually_exclusive: false,
+    last_updated_ts: '2026-06-01T15:00:00Z',
+};
+
+describe('eventRow', () => {
+    test('preserves event_ticker + series_ticker', () => {
+        const row = eventRow(EVENT_FIXTURE);
+        expect(row.event_ticker).toBe('KXBTC15M-26JUN011215');
+        expect(row.series_ticker).toBe('KXBTC15M');
+    });
+
+    test('coerces 0001-01-01 sentinel last_updated_ts to null', () => {
+        const row = eventRow({
+            ...EVENT_FIXTURE,
+            last_updated_ts: '0001-01-01T00:00:00Z',
+        });
+        expect(row.last_updated_ts).toBeNull();
+    });
+
+    test('defaults optional fields to empty string / false', () => {
+        const minimal: EventEntity = {
+            event_ticker: 'X-1',
+            series_ticker: 'X',
+            title: 'T',
+        };
+        const row = eventRow(minimal);
+        expect(row.sub_title).toBe('');
+        expect(row.mutually_exclusive).toBe(false);
+        expect(row.available_on_brokers).toBe(false);
+    });
+});
+
+const SERIES_FIXTURE: Series = {
+    ticker: 'KXHIGHNY',
+    title: 'Highest temperature in NYC',
+    category: 'Climate and Weather',
+    frequency: 'daily',
+    fee_type: 'quadratic',
+    fee_multiplier: 1,
+    tags: ['Daily temperature'],
+    settlement_sources: [
+        { name: 'NWS Climatological Report', url: 'https://example.com/nws' },
+    ],
+    additional_prohibitions: ['Prohibition A'],
+    contract_terms_url: 'https://example.com/terms.pdf',
+    contract_url: 'https://example.com/contract.pdf',
+    product_metadata: {
+        important_info: {
+            id: 'WEATHER-2025-3-3',
+            title: 'Important: ',
+            message: 'Not all weather data is the same.',
+            markdown: '**Important information**',
+        },
+    },
+    last_updated_ts: '2026-03-16T15:04:55.113254Z',
+};
+
+describe('seriesRow', () => {
+    test('flattens settlement_sources to parallel arrays', () => {
+        const row = seriesRow(SERIES_FIXTURE);
+        expect(row.settlement_source_names).toEqual([
+            'NWS Climatological Report',
+        ]);
+        expect(row.settlement_source_urls).toEqual(['https://example.com/nws']);
+    });
+
+    test('flattens product_metadata.important_info into individual columns', () => {
+        const row = seriesRow(SERIES_FIXTURE);
+        expect(row.important_info_id).toBe('WEATHER-2025-3-3');
+        expect(row.important_info_title).toBe('Important: ');
+        expect(row.important_info_message).toBe(
+            'Not all weather data is the same.',
+        );
+        expect(row.important_info_markdown).toBe('**Important information**');
+    });
+
+    test('handles missing product_metadata cleanly', () => {
+        const row = seriesRow({
+            ...SERIES_FIXTURE,
+            product_metadata: undefined,
+        });
+        expect(row.important_info_id).toBe('');
+        expect(row.important_info_title).toBe('');
+        expect(row.important_info_message).toBe('');
+        expect(row.important_info_markdown).toBe('');
+    });
+
+    test('preserves fractional fee_multiplier (Float64 schema)', () => {
+        // 9 of ~10K series (index futures) carry 0.5 — must not be int-cast.
+        const row = seriesRow({ ...SERIES_FIXTURE, fee_multiplier: 0.5 });
+        expect(row.fee_multiplier).toBe(0.5);
+    });
+
+    test('defaults fee_multiplier to 1 when missing', () => {
+        const row = seriesRow({ ...SERIES_FIXTURE, fee_multiplier: undefined });
+        expect(row.fee_multiplier).toBe(1);
+    });
+});
+
+const CANDLE_FIXTURE: Candlestick = {
+    end_period_ts: 1780329660,
+    volume_fp: '38015.34',
+    open_interest_fp: '23913.03',
+    price: {
+        open_dollars: '0.5500',
+        high_dollars: '0.7400',
+        low_dollars: '0.5100',
+        close_dollars: '0.6600',
+        mean_dollars: '0.6569',
+    },
+    yes_bid: {
+        open_dollars: '0.0000',
+        high_dollars: '0.7300',
+        low_dollars: '0.0000',
+        close_dollars: '0.6500',
+    },
+    yes_ask: {
+        open_dollars: '0.9990',
+        high_dollars: '0.9990',
+        low_dollars: '0.5100',
+        close_dollars: '0.6600',
+    },
+};
+
+describe('candleRow', () => {
+    test("maps period 1 to Enum16 label '1m'", () => {
+        expect(candleRow('X', 1, CANDLE_FIXTURE).period_interval).toBe('1m');
+    });
+
+    test("maps period 60 to '60m'", () => {
+        expect(candleRow('X', 60, CANDLE_FIXTURE).period_interval).toBe('60m');
+    });
+
+    test("maps period 1440 to '1440m'", () => {
+        expect(candleRow('X', 1440, CANDLE_FIXTURE).period_interval).toBe(
+            '1440m',
+        );
+    });
+
+    test('flattens nested OHLC objects into prefixed columns', () => {
+        const row = candleRow('X', 1, CANDLE_FIXTURE);
+        expect(row.price_open_dollars).toBe('0.5500');
+        expect(row.price_close_dollars).toBe('0.6600');
+        expect(row.price_mean_dollars).toBe('0.6569');
+        expect(row.yes_bid_open_dollars).toBe('0.0000');
+        expect(row.yes_ask_close_dollars).toBe('0.6600');
+    });
+
+    test('passes ticker + end_period_ts through unchanged', () => {
+        const row = candleRow('KXBTC15M-Y', 60, CANDLE_FIXTURE);
+        expect(row.ticker).toBe('KXBTC15M-Y');
+        expect(row.end_period_ts).toBe(1780329660);
+    });
+});

--- a/services/kalshi/normalize.ts
+++ b/services/kalshi/normalize.ts
@@ -10,7 +10,7 @@ const SENTINEL_TS_PREFIX = '0001-01-01';
 export function ts(s: string | null | undefined): string | null {
     if (!s) return null;
     if (s.startsWith(SENTINEL_TS_PREFIX)) return null;
-    return s.replace('Z', '');
+    return s.replace(/Z$/, '');
 }
 
 /** Empty string → NULL. */
@@ -135,16 +135,26 @@ export function seriesRow(s: Series) {
 }
 
 /** Map Kalshi's int period_interval (1/60/1440) to the CH Enum16 label. */
-const PERIOD_LABEL: Record<number, '1m' | '60m' | '1440m'> = {
+const PERIOD_LABEL = {
     1: '1m',
     60: '60m',
     1440: '1440m',
-};
+} as const satisfies Record<number, '1m' | '60m' | '1440m'>;
 
-export function candleRow(ticker: string, period: number, c: Candlestick) {
+export type PeriodInterval = keyof typeof PERIOD_LABEL;
+
+export function candleRow(
+    ticker: string,
+    period: PeriodInterval,
+    c: Candlestick,
+) {
+    const label = PERIOD_LABEL[period];
+    if (!label) {
+        throw new Error(`candleRow: unsupported period_interval ${period}`);
+    }
     return {
         ticker,
-        period_interval: PERIOD_LABEL[period],
+        period_interval: label,
         end_period_ts: c.end_period_ts,
         price_open_dollars: c.price.open_dollars,
         price_high_dollars: c.price.high_dollars,

--- a/services/kalshi/normalize.ts
+++ b/services/kalshi/normalize.ts
@@ -1,0 +1,165 @@
+// Kalshi sends sentinel `0001-01-01T00:00:00Z` for "never set" timestamps and
+// empty strings for unresolved fields. CH DateTime64 can't store the sentinel
+// and `WHERE x IS NULL` is cleaner than `x = ''`, so we normalize on write.
+
+import type { Candlestick, EventEntity, Market, Series, Trade } from './types';
+
+const SENTINEL_TS_PREFIX = '0001-01-01';
+
+/** ISO 8601 timestamp → CH-acceptable form, or NULL if missing/sentinel. */
+export function ts(s: string | null | undefined): string | null {
+    if (!s) return null;
+    if (s.startsWith(SENTINEL_TS_PREFIX)) return null;
+    return s.replace('Z', '');
+}
+
+/** Empty string → NULL. */
+export function nullIfEmpty(s: string | null | undefined): string | null {
+    return s ? s : null;
+}
+
+/** Decimal-string passthrough with a "0" floor for non-nullable columns. */
+export function dec(s: string | null | undefined): string {
+    return s ?? '0';
+}
+
+/** Decimal-string passthrough for nullable columns. */
+export function decOptional(s: string | null | undefined): string | null {
+    return s == null || s === '' ? null : s;
+}
+
+export function tradeRow(t: Trade) {
+    return {
+        trade_id: t.trade_id,
+        ticker: t.ticker,
+        created_time: ts(t.created_time),
+        count_fp: dec(t.count_fp),
+        yes_price_dollars: dec(t.yes_price_dollars),
+        no_price_dollars: dec(t.no_price_dollars),
+        taker_outcome_side: t.taker_outcome_side,
+        taker_book_side: t.taker_book_side,
+    };
+}
+
+export function marketRow(m: Market) {
+    const pr = m.price_ranges ?? [];
+    return {
+        ticker: m.ticker,
+        event_ticker: m.event_ticker,
+        mve_collection_ticker: m.mve_collection_ticker ?? '',
+        market_type: m.market_type,
+        status: m.status,
+        title: m.title,
+        yes_sub_title: m.yes_sub_title ?? '',
+        no_sub_title: m.no_sub_title ?? '',
+        rules_primary: m.rules_primary ?? '',
+        rules_secondary: m.rules_secondary ?? '',
+        created_time: ts(m.created_time),
+        open_time: ts(m.open_time),
+        close_time: ts(m.close_time),
+        expiration_time: ts(m.expiration_time),
+        expected_expiration_time: ts(m.expected_expiration_time),
+        latest_expiration_time: ts(m.latest_expiration_time),
+        occurrence_datetime: ts(m.occurrence_datetime),
+        settlement_timer_seconds: m.settlement_timer_seconds ?? 0,
+        can_close_early: m.can_close_early ?? false,
+        result: nullIfEmpty(m.result),
+        settlement_value_dollars: decOptional(m.settlement_value_dollars),
+        expiration_value: m.expiration_value ?? '',
+        is_provisional: m.is_provisional ?? null,
+        yes_bid_dollars: dec(m.yes_bid_dollars),
+        yes_ask_dollars: dec(m.yes_ask_dollars),
+        no_bid_dollars: dec(m.no_bid_dollars),
+        no_ask_dollars: dec(m.no_ask_dollars),
+        last_price_dollars: dec(m.last_price_dollars),
+        previous_yes_bid_dollars: dec(m.previous_yes_bid_dollars),
+        previous_yes_ask_dollars: dec(m.previous_yes_ask_dollars),
+        previous_price_dollars: dec(m.previous_price_dollars),
+        yes_bid_size_fp: dec(m.yes_bid_size_fp),
+        yes_ask_size_fp: dec(m.yes_ask_size_fp),
+        volume_fp: dec(m.volume_fp),
+        volume_24h_fp: dec(m.volume_24h_fp),
+        open_interest_fp: dec(m.open_interest_fp),
+        notional_value_dollars: dec(m.notional_value_dollars),
+        price_level_structure: m.price_level_structure ?? '',
+        response_price_units: m.response_price_units ?? '',
+        price_range_starts: pr.map((p) => p.start),
+        price_range_ends: pr.map((p) => p.end),
+        price_range_steps: pr.map((p) => p.step),
+        strike_type: m.strike_type ?? '',
+        floor_strike: m.floor_strike ?? null,
+        cap_strike: m.cap_strike ?? null,
+        functional_strike: m.functional_strike ?? '',
+        updated_time: ts(m.updated_time),
+    };
+}
+
+export function eventRow(e: EventEntity) {
+    return {
+        event_ticker: e.event_ticker,
+        series_ticker: e.series_ticker,
+        title: e.title,
+        sub_title: e.sub_title ?? '',
+        category: e.category ?? '',
+        mutually_exclusive: e.mutually_exclusive ?? false,
+        collateral_return_type: e.collateral_return_type ?? '',
+        strike_date: ts(e.strike_date),
+        strike_period: e.strike_period ?? '',
+        available_on_brokers: e.available_on_brokers ?? false,
+        last_updated_ts: ts(e.last_updated_ts),
+    };
+}
+
+export function seriesRow(s: Series) {
+    const sources = s.settlement_sources ?? [];
+    const ii = s.product_metadata?.important_info ?? {};
+    return {
+        ticker: s.ticker,
+        title: s.title,
+        category: s.category ?? '',
+        frequency: s.frequency ?? '',
+        fee_type: s.fee_type ?? '',
+        fee_multiplier: s.fee_multiplier ?? 1,
+        tags: s.tags ?? [],
+        settlement_source_names: sources.map((x) => x.name),
+        settlement_source_urls: sources.map((x) => x.url),
+        additional_prohibitions: s.additional_prohibitions ?? [],
+        contract_terms_url: s.contract_terms_url ?? '',
+        contract_url: s.contract_url ?? '',
+        important_info_id: ii.id ?? '',
+        important_info_title: ii.title ?? '',
+        important_info_message: ii.message ?? '',
+        important_info_markdown: ii.markdown ?? '',
+        last_updated_ts: ts(s.last_updated_ts),
+    };
+}
+
+/** Map Kalshi's int period_interval (1/60/1440) to the CH Enum16 label. */
+const PERIOD_LABEL: Record<number, '1m' | '60m' | '1440m'> = {
+    1: '1m',
+    60: '60m',
+    1440: '1440m',
+};
+
+export function candleRow(ticker: string, period: number, c: Candlestick) {
+    return {
+        ticker,
+        period_interval: PERIOD_LABEL[period],
+        end_period_ts: c.end_period_ts,
+        price_open_dollars: c.price.open_dollars,
+        price_high_dollars: c.price.high_dollars,
+        price_low_dollars: c.price.low_dollars,
+        price_close_dollars: c.price.close_dollars,
+        price_mean_dollars: c.price.mean_dollars,
+        yes_bid_open_dollars: c.yes_bid.open_dollars,
+        yes_bid_high_dollars: c.yes_bid.high_dollars,
+        yes_bid_low_dollars: c.yes_bid.low_dollars,
+        yes_bid_close_dollars: c.yes_bid.close_dollars,
+        yes_ask_open_dollars: c.yes_ask.open_dollars,
+        yes_ask_high_dollars: c.yes_ask.high_dollars,
+        yes_ask_low_dollars: c.yes_ask.low_dollars,
+        yes_ask_close_dollars: c.yes_ask.close_dollars,
+        volume_fp: c.volume_fp,
+        open_interest_fp: c.open_interest_fp,
+    };
+}

--- a/services/kalshi/normalize.ts
+++ b/services/kalshi/normalize.ts
@@ -4,7 +4,7 @@
 
 import type { Candlestick, EventEntity, Market, Series, Trade } from './types';
 
-const SENTINEL_TS_PREFIX = '0001-01-01';
+export const SENTINEL_TS_PREFIX = '0001-01-01';
 
 /** ISO 8601 timestamp → CH-acceptable form, or NULL if missing/sentinel. */
 export function ts(s: string | null | undefined): string | null {

--- a/services/kalshi/types.ts
+++ b/services/kalshi/types.ts
@@ -1,0 +1,162 @@
+// Kalshi Trade API v2 response shapes.
+
+export interface TradesPage {
+    cursor: string;
+    trades: Trade[];
+}
+export interface MarketsPage {
+    cursor: string;
+    markets: Market[];
+}
+export interface EventsPage {
+    cursor: string;
+    events: EventEntity[];
+}
+export interface SeriesPage {
+    series: Series[];
+}
+export interface CandlesPage {
+    ticker: string;
+    candlesticks: Candlestick[];
+}
+
+/** Bulk-candlesticks endpoint groups bars per ticker. Note: `market_ticker`, not `ticker`. */
+export interface BulkCandlesPage {
+    markets: Array<{
+        market_ticker: string;
+        candlesticks: Candlestick[];
+    }>;
+}
+
+export interface HistoricalCutoff {
+    market_settled_ts: string;
+    orders_updated_ts: string;
+    trades_created_ts: string;
+}
+
+export interface Trade {
+    trade_id: string;
+    ticker: string;
+    created_time: string;
+    count_fp: string;
+    yes_price_dollars: string;
+    no_price_dollars: string;
+    taker_outcome_side: 'yes' | 'no';
+    taker_book_side: 'bid' | 'ask';
+    taker_side?: string;
+}
+
+export interface Market {
+    ticker: string;
+    event_ticker: string;
+    mve_collection_ticker?: string;
+    market_type: 'binary' | 'scalar';
+    status: string;
+    title: string;
+    yes_sub_title?: string;
+    no_sub_title?: string;
+    rules_primary?: string;
+    rules_secondary?: string;
+
+    created_time: string;
+    open_time?: string;
+    close_time?: string;
+    expiration_time?: string;
+    expected_expiration_time?: string;
+    latest_expiration_time?: string;
+    occurrence_datetime?: string;
+    settlement_timer_seconds?: number;
+    can_close_early?: boolean;
+
+    result?: string;
+    settlement_value_dollars?: string;
+    expiration_value?: string;
+    is_provisional?: boolean | null;
+
+    yes_bid_dollars: string;
+    yes_ask_dollars: string;
+    no_bid_dollars: string;
+    no_ask_dollars: string;
+    last_price_dollars: string;
+    previous_yes_bid_dollars?: string;
+    previous_yes_ask_dollars?: string;
+    previous_price_dollars?: string;
+
+    yes_bid_size_fp?: string;
+    yes_ask_size_fp?: string;
+
+    volume_fp?: string;
+    volume_24h_fp?: string;
+    open_interest_fp?: string;
+
+    notional_value_dollars?: string;
+    price_level_structure?: string;
+    response_price_units?: string;
+    price_ranges?: PriceRange[];
+    strike_type?: string;
+    floor_strike?: number | null;
+    cap_strike?: number | null;
+    functional_strike?: string;
+
+    updated_time: string;
+}
+
+export interface PriceRange {
+    start: string;
+    end: string;
+    step: string;
+}
+
+export interface EventEntity {
+    event_ticker: string;
+    series_ticker: string;
+    title: string;
+    sub_title?: string;
+    category?: string;
+    mutually_exclusive?: boolean;
+    collateral_return_type?: string;
+    strike_date?: string;
+    strike_period?: string;
+    available_on_brokers?: boolean;
+    last_updated_ts?: string;
+    markets?: Market[];
+}
+
+export interface Series {
+    ticker: string;
+    title: string;
+    category?: string;
+    frequency?: string;
+    fee_type?: string;
+    fee_multiplier?: number; // observed fractional (0.5) on index series — keep number, not int
+    tags?: string[];
+    settlement_sources?: { name: string; url: string }[];
+    additional_prohibitions?: string[];
+    contract_terms_url?: string;
+    contract_url?: string;
+    product_metadata?: {
+        important_info?: {
+            id?: string;
+            title?: string;
+            message?: string;
+            markdown?: string;
+        };
+    };
+    last_updated_ts?: string;
+}
+
+export interface CandleOHLC {
+    open_dollars: string;
+    high_dollars: string;
+    low_dollars: string;
+    close_dollars: string;
+}
+
+export interface Candlestick {
+    end_period_ts: number;
+    volume_fp: string;
+    open_interest_fp: string;
+    price: CandleOHLC & { mean_dollars: string };
+    yes_bid: CandleOHLC;
+    yes_ask: CandleOHLC;
+}

--- a/sql.schemas/schema.kalshi.sql
+++ b/sql.schemas/schema.kalshi.sql
@@ -1,0 +1,189 @@
+-- Kalshi prediction-market data (scraped from Kalshi Trade API v2).
+--
+-- Populated by the `kalshi-live` scraper service polling the public REST API
+-- (https://api.elections.kalshi.com/trade-api/v2/*). No auth required for any
+-- market-data endpoint used here.
+--
+-- Apply via: npm run cli setup kalshi --clickhouse-database <db>
+
+-- ============================================================
+-- Series — Kalshi recurring contract templates (~10K rows, slow-changing).
+-- ============================================================
+CREATE TABLE IF NOT EXISTS series (
+    ticker                      String                          COMMENT 'series ticker (e.g. KXHIGHNY), unique',
+    title                       String,
+    category                    LowCardinality(String)          COMMENT 'Politics / Sports / Climate and Weather / Crypto / Entertainment / ...',
+    frequency                   LowCardinality(String)          COMMENT 'one_off | daily | weekly | ...',
+    fee_type                    LowCardinality(String)          COMMENT 'quadratic | ...',
+    fee_multiplier              Float64                         COMMENT 'observed fractional values (0.5) for index series — must be Float, not Int',
+    tags                        Array(String),
+    settlement_source_names     Array(String)                   COMMENT 'parallel array with settlement_source_urls',
+    settlement_source_urls      Array(String),
+    additional_prohibitions     Array(String),
+    contract_terms_url          String,
+    contract_url                String,
+    important_info_id           String                          COMMENT 'product_metadata.important_info.* (flattened)',
+    important_info_title        String,
+    important_info_message      String,
+    important_info_markdown     String,
+
+    last_updated_ts             Nullable(DateTime64(6, 'UTC'))  COMMENT 'source-provided, sentinel 0001-01-01 coerced to NULL on write',
+    ingested_at                 DateTime64(6, 'UTC') DEFAULT now64(6)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+ORDER BY ticker
+COMMENT 'Kalshi series catalogue (scraper-managed)';
+
+-- ============================================================
+-- Events — one real-world occurrence; groups one or more markets.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS events (
+    event_ticker                String                          COMMENT 'e.g. KXBTC15M-26JUN011215',
+    series_ticker               String                          COMMENT 'FK to series.ticker',
+    title                       String,
+    sub_title                   String,
+    category                    LowCardinality(String),
+    mutually_exclusive          Bool,
+    collateral_return_type      LowCardinality(String),
+    strike_date                 Nullable(DateTime64(6, 'UTC')),
+    strike_period               String,
+    available_on_brokers        Bool,
+
+    last_updated_ts             Nullable(DateTime64(6, 'UTC'))  COMMENT 'source-provided, sentinel 0001-01-01 coerced to NULL on write',
+    ingested_at                 DateTime64(6, 'UTC') DEFAULT now64(6)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+ORDER BY event_ticker
+COMMENT 'Kalshi event metadata (scraper-managed)';
+
+-- ============================================================
+-- Markets — binary or scalar contracts. Latest state per ticker.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS markets (
+    ticker                      String                          COMMENT 'unique market ticker (e.g. KXBTC15M-26JUN011215-15)',
+    event_ticker                String                          COMMENT 'FK to events.event_ticker',
+    mve_collection_ticker       String                          COMMENT 'multivariate event collection, empty for non-multivariate',
+    market_type                 LowCardinality(String)          COMMENT 'binary | scalar',
+    status                      LowCardinality(String)          COMMENT 'Kalshi stored vocab is initialized/active/inactive/closed/finalized, filter vocab differs (unopened/open/paused/closed/settled)',
+    title                       String,
+    yes_sub_title               String,
+    no_sub_title                String,
+    rules_primary               String,
+    rules_secondary             String,
+
+    created_time                DateTime64(6, 'UTC'),
+    open_time                   Nullable(DateTime64(6, 'UTC')),
+    close_time                  Nullable(DateTime64(6, 'UTC')),
+    expiration_time             Nullable(DateTime64(6, 'UTC')),
+    expected_expiration_time    Nullable(DateTime64(6, 'UTC')),
+    latest_expiration_time      Nullable(DateTime64(6, 'UTC')),
+    occurrence_datetime         Nullable(DateTime64(6, 'UTC')),
+    settlement_timer_seconds    Int32,
+    can_close_early             Bool,
+
+    result                      Nullable(String)                COMMENT 'yes/no/scalar/NULL when unresolved, empty string coerced to NULL on write',
+    settlement_value_dollars    Nullable(Decimal(18, 6)),
+    expiration_value            String,
+    is_provisional              Nullable(Bool),
+
+    yes_bid_dollars             Decimal(18, 6)                  COMMENT 'FixedPointDollars (docs cap 6dp, observed 4dp)',
+    yes_ask_dollars             Decimal(18, 6),
+    no_bid_dollars              Decimal(18, 6),
+    no_ask_dollars              Decimal(18, 6),
+    last_price_dollars          Decimal(18, 6),
+    previous_yes_bid_dollars    Decimal(18, 6),
+    previous_yes_ask_dollars    Decimal(18, 6),
+    previous_price_dollars      Decimal(18, 6),
+
+    yes_bid_size_fp             Decimal(18, 4)                  COMMENT 'FixedPointCount (2dp per docs, scale headroom)',
+    yes_ask_size_fp             Decimal(18, 4),
+
+    volume_fp                   Decimal(18, 4),
+    volume_24h_fp               Decimal(18, 4),
+    open_interest_fp            Decimal(18, 4),
+
+    notional_value_dollars      Decimal(18, 6)                  COMMENT 'settlement value per contract (typically $1.00)',
+    price_level_structure       LowCardinality(String),
+    response_price_units        LowCardinality(String),
+    price_range_starts          Array(Decimal(18, 6))           COMMENT 'parallel arrays from price_ranges[].{start,end,step}',
+    price_range_ends            Array(Decimal(18, 6)),
+    price_range_steps           Array(Decimal(18, 6)),
+    strike_type                 LowCardinality(String),
+    floor_strike                Nullable(Float64),
+    cap_strike                  Nullable(Float64),
+    functional_strike           String,
+
+    updated_time                DateTime64(6, 'UTC')            COMMENT 'source-provided, used as merge tie-breaker via ingested_at version',
+    ingested_at                 DateTime64(6, 'UTC') DEFAULT now64(6)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(created_time)
+ORDER BY ticker
+COMMENT 'Kalshi markets latest-state (scraper-managed)';
+
+-- ============================================================
+-- Trades — append-only fill history.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS trades (
+    trade_id                    UUID                            COMMENT 'Kalshi trade identifier',
+    ticker                      String                          COMMENT 'FK to markets.ticker',
+    created_time                DateTime64(6, 'UTC')            COMMENT 'fill time (μs precision)',
+    count_fp                    Decimal(18, 4)                  COMMENT 'contracts (FixedPointCount)',
+    yes_price_dollars           Decimal(18, 6),
+    no_price_dollars            Decimal(18, 6)                  COMMENT 'yes + no = 1.0000',
+    taker_outcome_side          Enum8('yes' = 1, 'no' = 2),
+    taker_book_side             Enum8('bid' = 1, 'ask' = 2),
+
+    ingested_at                 DateTime64(6, 'UTC') DEFAULT now64(6)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(created_time)
+ORDER BY (ticker, created_time, trade_id)
+COMMENT 'Kalshi trade fills (scraper-managed). RMT dedups on (ticker, created_time, trade_id) for retry-safe inserts. Use FINAL on read only when exact aggregation matters.';
+
+-- ============================================================
+-- Candlesticks — server-aggregated 1m / 60m / 1440m bars.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS candlesticks (
+    ticker                      String,
+    period_interval             Enum16('1m' = 1, '60m' = 60, '1440m' = 1440) COMMENT 'Kalshi period_interval in minutes',
+    end_period_ts               DateTime('UTC')                 COMMENT 'bar close time (unix int from source)',
+
+    price_open_dollars          Decimal(18, 6)                  COMMENT 'OHLC on YES price',
+    price_high_dollars          Decimal(18, 6),
+    price_low_dollars           Decimal(18, 6),
+    price_close_dollars         Decimal(18, 6),
+    price_mean_dollars          Decimal(18, 6),
+
+    yes_bid_open_dollars        Decimal(18, 6)                  COMMENT 'OHLC on top-of-book bid',
+    yes_bid_high_dollars        Decimal(18, 6),
+    yes_bid_low_dollars         Decimal(18, 6),
+    yes_bid_close_dollars       Decimal(18, 6),
+
+    yes_ask_open_dollars        Decimal(18, 6)                  COMMENT 'OHLC on top-of-book ask',
+    yes_ask_high_dollars        Decimal(18, 6),
+    yes_ask_low_dollars         Decimal(18, 6),
+    yes_ask_close_dollars       Decimal(18, 6),
+
+    volume_fp                   Decimal(18, 4),
+    open_interest_fp            Decimal(18, 4)                  COMMENT 'OI at bar close',
+
+    ingested_at                 DateTime64(6, 'UTC') DEFAULT now64(6)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY (period_interval, toYYYYMM(end_period_ts))
+ORDER BY (ticker, period_interval, end_period_ts)
+COMMENT 'Kalshi server-aggregated candlesticks (scraper-managed)';
+
+-- ============================================================
+-- Cursor checkpoints — resumable polling across restarts.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS cursor_state (
+    scope                       String                          COMMENT 'logical scope, e.g. trades_live | trades_historical | markets_active',
+    last_cursor                 String                          COMMENT 'opaque Kalshi cursor token',
+    last_processed_ts           DateTime64(6, 'UTC')            COMMENT 'created_time of the last processed item',
+    updated_at                  DateTime64(6, 'UTC') DEFAULT now64(6)
+)
+ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY scope
+COMMENT 'Per-scope cursor checkpoints for the kalshi scraper';


### PR DESCRIPTION
## Summary
- Adds `kalshi-live` service for the Kalshi Trade API v2 — scrapes trades, markets, events, series, and candlesticks into a `kalshi` ClickHouse database.
- New CLI commands: `npm run cli run kalshi-live`, `npm run cli setup kalshi`.

## Why
Phase 1 of the prediction-markets pipeline. Kalshi is structurally off-chain-native, so the scraper is the primary ingest (not enrichment over a substreams pipeline like our other scrapers). Live mode tip-follows; backfill is a follow-up branch.

## Notable design choices
- **Trades engine `ReplacingMergeTree`** keyed `(ticker, created_time, trade_id)` — retry-safe inserts. Use `FINAL` on read only when exact aggregation matters.
- **Drain to watermark every cycle, no page cap.** If the scraper falls behind, one long cycle catches up then steady-state resumes. Matches the substreams live-sink semantic.
- **Full µs precision preserved across the cursor boundary.** `setCursor` accepts ISO 8601 strings; `getCursors` returns both ms (for refresh-pass clocks) and full ISO (for trade-row compares).
- **Refresh passes are incremental.** Each pass tracks `min_updated_ts` in its scope's checkpoint, so cold-start work is bounded to one cadence window.
- **Status stored as Kalshi returns it.** The filter vocab (\`open/closed/settled\`) and stored vocab (\`active/closed/finalized\`) differ; the `/v1/kalshi/markets` route handler will translate when that endpoint lands.

## Code map
- `sql.schemas/schema.kalshi.sql` — six tables, designed to survive \`transformSqlForCluster\` for Replicated deployments.
- `services/kalshi/client.ts` — REST client with retry/backoff + AbortSignal timeout.
- `services/kalshi/cursor.ts` — per-scope checkpoint, batched read in one CH round-trip.
- `services/kalshi/live.ts` — multi-pass cycle orchestration with per-pass error attribution.
- `services/kalshi/normalize.ts` — write-path coercions (sentinel timestamps, empty-string → NULL, decimal passthrough).
- `services/kalshi/types.ts` — Kalshi response shapes.
- `services/kalshi/{*.test.ts,*.integration.test.ts}` — offline + integration test suites.
- `cli.ts` — `setup kalshi` + `run kalshi-live` wiring.
- `lib/batch-insert.ts` — \`shutdownBatchInsertQueue\` finally-block tweak so a thrown shutdown doesn't orphan the global queue.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)