### PR TITLE
feat(scraper): emit per-scope freshness + write-path metrics

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -5,7 +5,12 @@ import { resolve } from 'path';
 import { client } from './lib/clickhouse';
 import { DEFAULT_CONFIG } from './lib/config';
 import { createLogger } from './lib/logger';
-import { startPrometheusServer, stopPrometheusServer } from './lib/prometheus';
+import {
+    observeCycleDuration,
+    setServiceNameLabel,
+    startPrometheusServer,
+    stopPrometheusServer,
+} from './lib/prometheus';
 import { executeSqlSetup, promptClusterSelection } from './lib/setup';
 
 const log = createLogger('cli');
@@ -345,8 +350,14 @@ async function runService(serviceName: string, options: ServiceOptions) {
     // Run the service in a continuous loop
     let iteration = 0;
 
+    // Label per-service metrics from the runner side too, so cycle-duration
+    // observations from the loop below carry the right service name even
+    // before the imported service module calls `initService` on its first run.
+    setServiceNameLabel(serviceName);
+
     while (true) {
         iteration++;
+        const cycleStart = performance.now();
         try {
             if (options.verbose && iteration > 1) {
                 log.info(`Starting iteration ${iteration}`);
@@ -354,6 +365,10 @@ async function runService(serviceName: string, options: ServiceOptions) {
 
             // Run the service
             await serviceModule.run();
+            observeCycleDuration(
+                (performance.now() - cycleStart) / 1000,
+                'success',
+            );
 
             if (options.verbose) {
                 log.info('Service iteration completed', {
@@ -373,6 +388,10 @@ async function runService(serviceName: string, options: ServiceOptions) {
                 setTimeout(resolve, autoRestartDelay * 1000),
             );
         } catch (error) {
+            observeCycleDuration(
+                (performance.now() - cycleStart) / 1000,
+                'error',
+            );
             log.error('Service error', { error });
             // Close Prometheus server on error
             await stopPrometheusServer();

--- a/lib/batch-insert.ts
+++ b/lib/batch-insert.ts
@@ -1,7 +1,7 @@
 import { insertClient } from './clickhouse';
 import { NODE_URL } from './config';
 import { createLogger } from './logger';
-import { trackClickHouseOperation } from './prometheus';
+import { incrementRowsInserted, trackClickHouseOperation } from './prometheus';
 
 const log = createLogger('batch-insert');
 
@@ -74,6 +74,7 @@ export class BatchInsertQueue {
         try {
             await this.insertImmediate(table, items);
             trackClickHouseOperation('write', 'success', startTime);
+            incrementRowsInserted(table, items.length);
             this.lastSuccessfulFlushAt = Date.now();
             this.lastFlushError = undefined;
             return 'ok';

--- a/lib/prometheus.ts
+++ b/lib/prometheus.ts
@@ -71,6 +71,94 @@ const rpcRequests = new promClient.Histogram({
     registers: [register],
 });
 
+// Per-scope freshness — analogue to substreams-sink-sql `head_block_number`.
+// Unix seconds (float) of the newest record this scope has processed. Grafana
+// computes drift as `time() - scraper_head_time_seconds`, matching the
+// `head_block_time_drift` panels on the public stats dashboard.
+const headTimeGauge = new promClient.Gauge({
+    name: 'scraper_head_time_seconds',
+    help: 'Unix timestamp (seconds) of the most recent record processed by this scope',
+    labelNames: ['service', 'scope'],
+    registers: [register],
+});
+
+// Backfill scope reached `__DRAINED__` — analogue to
+// `substreams_sink_backprocessing_completion`. Reset to 0 when the scope
+// resumes (operator cleared the row or the next cycle re-engaged).
+const backfillDrainedGauge = new promClient.Gauge({
+    name: 'scraper_backfill_drained',
+    help: 'Set to 1 when a backfill scope has fully drained its source',
+    labelNames: ['service', 'scope'],
+    registers: [register],
+});
+
+// Scope was quarantined due to a cursor loop (`__POISONED__`). No substreams
+// analogue — but the state is operationally important: cycle won't advance
+// until the row is cleared manually.
+const poisonedGauge = new promClient.Gauge({
+    name: 'scraper_poisoned',
+    help: 'Set to 1 when a scope has been quarantined due to a cursor loop',
+    labelNames: ['service', 'scope'],
+    registers: [register],
+});
+
+// Rows successfully written to ClickHouse — analogue to
+// `substreams_sink_postgres_flushed_rows_count`.
+const rowsInsertedCounter = new promClient.Counter({
+    name: 'scraper_rows_inserted_total',
+    help: 'Total rows successfully inserted into ClickHouse, by destination table',
+    labelNames: ['service', 'table'],
+    registers: [register],
+});
+
+// Pages received from the upstream API — analogue to
+// `substreams_sink_data_message`. Granularity is page (one HTTP response),
+// not item.
+const pagesReceivedCounter = new promClient.Counter({
+    name: 'scraper_pages_received_total',
+    help: 'Total upstream pages received, by scope',
+    labelNames: ['service', 'scope'],
+    registers: [register],
+});
+
+// Items dropped before queue.add() — typically Kalshi `0001-01-01` sentinels
+// that would null-out into non-nullable CH columns. Surfaces silent skips.
+const itemsSkippedCounter = new promClient.Counter({
+    name: 'scraper_items_skipped_total',
+    help: 'Total upstream items skipped before insert, by destination table and reason',
+    labelNames: ['service', 'table', 'reason'],
+    registers: [register],
+});
+
+// Upstream HTTP errors — more granular than the existing
+// `scraper_error_tasks_total{service}` so dashboards can drill into which
+// endpoint or status code is failing.
+const httpErrorsCounter = new promClient.Counter({
+    name: 'scraper_http_errors_total',
+    help: 'Upstream HTTP errors, by endpoint and status code',
+    labelNames: ['service', 'endpoint', 'status_code'],
+    registers: [register],
+});
+
+// Wallclock per full `run()` invocation, labelled by outcome so a slow-cycle
+// alert can distinguish "still finishing healthy" from "throwing late".
+const cycleDurationHistogram = new promClient.Histogram({
+    name: 'scraper_cycle_duration_seconds',
+    help: 'Duration of one complete service cycle in seconds',
+    labelNames: ['service', 'outcome'],
+    buckets: [0.1, 0.5, 1, 5, 10, 30, 60, 120, 300, 600],
+    registers: [register],
+});
+
+// Cached at `initService` so metric helpers below don't need the service name
+// threaded through every call site. Falls back to `'unknown'` if a helper
+// fires before init (e.g. in a test that imports a module directly).
+let serviceNameLabel = 'unknown';
+
+export function setServiceNameLabel(name: string): void {
+    serviceNameLabel = name;
+}
+
 // Configuration info metrics
 const configInfoGauge = new promClient.Gauge({
     name: 'scraper_config_info',
@@ -256,4 +344,58 @@ export function trackRpcRequest(
 ): void {
     const durationSeconds = (performance.now() - startTime) / 1000;
     rpcRequests.labels(method, status).observe(durationSeconds);
+}
+
+/** Record the newest record-timestamp this scope has processed. Accepts ISO
+ * 8601 (with or without fractional seconds) or unix-ms; converts to unix
+ * seconds with sub-second precision preserved when present. */
+export function setScopeHeadTime(
+    scope: string,
+    timestamp: string | number,
+): void {
+    const seconds =
+        typeof timestamp === 'number'
+            ? timestamp / 1000
+            : new Date(timestamp).getTime() / 1000;
+    if (!Number.isFinite(seconds)) return;
+    headTimeGauge.labels(serviceNameLabel, scope).set(seconds);
+}
+
+/** Mark a backfill scope as drained (1) or resumed (0). */
+export function setBackfillDrained(scope: string, drained: boolean): void {
+    backfillDrainedGauge.labels(serviceNameLabel, scope).set(drained ? 1 : 0);
+}
+
+/** Mark a scope as quarantined (1) or healthy (0). */
+export function setScopePoisoned(scope: string, poisoned: boolean): void {
+    poisonedGauge.labels(serviceNameLabel, scope).set(poisoned ? 1 : 0);
+}
+
+export function incrementRowsInserted(table: string, count: number): void {
+    if (count > 0)
+        rowsInsertedCounter.labels(serviceNameLabel, table).inc(count);
+}
+
+export function incrementPagesReceived(scope: string): void {
+    pagesReceivedCounter.labels(serviceNameLabel, scope).inc();
+}
+
+export function incrementItemsSkipped(table: string, reason: string): void {
+    itemsSkippedCounter.labels(serviceNameLabel, table, reason).inc();
+}
+
+export function incrementHttpErrors(
+    endpoint: string,
+    statusCode: number | string,
+): void {
+    httpErrorsCounter
+        .labels(serviceNameLabel, endpoint, String(statusCode))
+        .inc();
+}
+
+export function observeCycleDuration(
+    seconds: number,
+    outcome: 'success' | 'error',
+): void {
+    cycleDurationHistogram.labels(serviceNameLabel, outcome).observe(seconds);
 }

--- a/lib/prometheus.ts
+++ b/lib/prometheus.ts
@@ -347,8 +347,10 @@ export function trackRpcRequest(
 }
 
 /** Record the newest record-timestamp this scope has processed. Accepts ISO
- * 8601 (with or without fractional seconds) or unix-ms; converts to unix
- * seconds with sub-second precision preserved when present. */
+ * 8601 or unix-ms. Resolution is millisecond — `new Date(iso)` truncates
+ * anything beyond 3 fractional digits, so µs-precision Kalshi timestamps
+ * land in the gauge at ms granularity. Sufficient for dashboard freshness
+ * panels; not load-bearing for sub-ms accuracy. */
 export function setScopeHeadTime(
     scope: string,
     timestamp: string | number,

--- a/lib/service-init.ts
+++ b/lib/service-init.ts
@@ -11,7 +11,7 @@ import {
     DEFAULT_CONFIG,
 } from './config';
 import { createLogger } from './logger';
-import { setLivenessSource } from './prometheus';
+import { setLivenessSource, setServiceNameLabel } from './prometheus';
 
 const log = createLogger('service');
 
@@ -39,6 +39,10 @@ export interface ServiceInitOptions {
  * - Logs service startup information
  */
 export function initService(options: ServiceInitOptions): void {
+    // Label all per-service metrics emitted from shared lib code (batch-insert,
+    // cursor) without threading the name through every call site.
+    setServiceNameLabel(options.serviceName);
+
     // Initialize batch insert queue
     initBatchInsertQueue({
         intervalMs: BATCH_INSERT_INTERVAL_MS,

--- a/services/kalshi/backfill.ts
+++ b/services/kalshi/backfill.ts
@@ -8,7 +8,14 @@ import {
     shutdownBatchInsertQueue,
 } from '../../lib/batch-insert';
 import { createLogger } from '../../lib/logger';
-import { incrementError, incrementSuccess } from '../../lib/prometheus';
+import {
+    incrementError,
+    incrementItemsSkipped,
+    incrementPagesReceived,
+    incrementSuccess,
+    setBackfillDrained,
+    setScopePoisoned,
+} from '../../lib/prometheus';
 import { initService, markServiceAlive } from '../../lib/service-init';
 import { KalshiClient } from './client';
 import { getCursor, setCursor } from './cursor';
@@ -50,6 +57,10 @@ export async function run(): Promise<void> {
 
     try {
         const prev = await getCursor(SCOPE);
+        // Reassert state gauges every cycle. If an operator clears the
+        // row the next cycle resets these to 0 without code changes.
+        setBackfillDrained(SCOPE, prev?.last_cursor === DRAINED_SENTINEL);
+        setScopePoisoned(SCOPE, prev?.last_cursor === POISONED_SENTINEL);
         if (prev?.last_cursor === DRAINED_SENTINEL) {
             log.info('backfill archive drained, idling', {
                 oldest_seen: prev.last_processed_ts_iso,
@@ -147,6 +158,7 @@ export async function runTradesBackfill(
 
     while (pages < MAX_PAGES_PER_CYCLE) {
         const page = await client.getTradesHistorical({ cursor, limit: 1000 });
+        incrementPagesReceived(SCOPE);
 
         // Server hiccups (empty body / brief 200 with no content) return
         // {trades: [], cursor: ''}. Distinguishing a true drain from a
@@ -172,6 +184,7 @@ export async function runTradesBackfill(
                     trade_id: t.trade_id,
                     ticker: t.ticker,
                 });
+                incrementItemsSkipped('trades', 'sentinel_created_time');
                 continue;
             }
             await queue.add('trades', tradeRow(t));

--- a/services/kalshi/client.ts
+++ b/services/kalshi/client.ts
@@ -3,6 +3,7 @@
 
 import { DEFAULT_CONFIG } from '../../lib/config';
 import { createLogger } from '../../lib/logger';
+import { incrementHttpErrors } from '../../lib/prometheus';
 import type {
     BulkCandlesPage,
     CandlesPage,
@@ -53,6 +54,13 @@ const RETRYABLE_FETCH_ERRORS = [
 function isRetryableFetchError(err: unknown): boolean {
     const msg = String((err as Error)?.message || err || '').toLowerCase();
     return RETRYABLE_FETCH_ERRORS.some((s) => msg.includes(s));
+}
+
+/** Collapse dynamic ticker segments to bounded route templates so the
+ * Prometheus `endpoint` label cardinality stays tied to the endpoint surface,
+ * not the universe of Kalshi tickers. */
+function normalizeEndpoint(path: string): string {
+    return path.replace(/\/[A-Z][A-Z0-9_-]*/g, '/{X}');
 }
 
 export class KalshiClient {
@@ -120,6 +128,7 @@ export class KalshiClient {
             const retryable = RETRYABLE_STATUSES.has(resp.status);
             if (!retryable || attempt >= this.opts.maxRetries) {
                 const body = await resp.text();
+                incrementHttpErrors(normalizeEndpoint(path), resp.status);
                 throw new Error(
                     `Kalshi ${resp.status} on GET ${path}: ${body.slice(0, 240)}`,
                 );

--- a/services/kalshi/cursor.ts
+++ b/services/kalshi/cursor.ts
@@ -5,6 +5,7 @@
 // as a clock — `last_processed_ts` is the time of the last successful run.
 
 import { insertClient, query } from '../../lib/clickhouse';
+import { setScopeHeadTime } from '../../lib/prometheus';
 
 export interface CursorCheckpoint {
     scope: string;
@@ -75,6 +76,7 @@ export async function setCursor(
         values: [{ scope, last_cursor, last_processed_ts: persisted }],
         format: 'JSONEachRow',
     });
+    setScopeHeadTime(scope, last_processed_ts_iso);
 }
 
 /** True if `intervalSec` has elapsed since `lastMs` (or no prior run exists). */

--- a/services/kalshi/live.ts
+++ b/services/kalshi/live.ts
@@ -479,12 +479,15 @@ function runMarketsPass(
         // markets.created_time + markets.updated_time are non-nullable in CH.
         // `ts()` would coerce the Kalshi sentinel to null and the batch insert
         // would then fail; drop the row before it reaches the queue.
+        // Skip reason strings double as `scraper_items_skipped_total.reason`
+        // labels — use snake_case to stay consistent with the same skip
+        // condition in kalshi-backfill's markets pass.
         skip: (m) => {
             if (m.created_time?.startsWith(SENTINEL_TS_PREFIX)) {
-                return 'sentinel created_time';
+                return 'sentinel_created_time';
             }
             if (m.updated_time?.startsWith(SENTINEL_TS_PREFIX)) {
-                return 'sentinel updated_time';
+                return 'sentinel_updated_time';
             }
             return undefined;
         },

--- a/services/kalshi/live.ts
+++ b/services/kalshi/live.ts
@@ -7,7 +7,13 @@ import {
 } from '../../lib/batch-insert';
 import { query } from '../../lib/clickhouse';
 import { createLogger } from '../../lib/logger';
-import { incrementError, incrementSuccess } from '../../lib/prometheus';
+import {
+    incrementError,
+    incrementItemsSkipped,
+    incrementPagesReceived,
+    incrementSuccess,
+    setScopePoisoned,
+} from '../../lib/prometheus';
 import { initService, markServiceAlive } from '../../lib/service-init';
 import { KalshiClient } from './client';
 import {
@@ -82,6 +88,21 @@ export async function run(): Promise<void> {
             SCOPE_SERIES,
             SCOPE_CANDLES,
         ]);
+
+        // Reassert quarantine gauges every cycle so an operator clearing
+        // `__POISONED__` is reflected without a code change.
+        for (const scope of [
+            SCOPE_TRADES,
+            SCOPE_MARKETS,
+            SCOPE_EVENTS,
+            SCOPE_SERIES,
+            SCOPE_CANDLES,
+        ]) {
+            setScopePoisoned(
+                scope,
+                cursors.get(scope)?.last_cursor === POISONED_SENTINEL,
+            );
+        }
 
         await runPass(
             cursors,
@@ -272,6 +293,7 @@ async function runTradesPass(
             cursor,
             limit: 1000,
         });
+        incrementPagesReceived(SCOPE_TRADES);
 
         if (page.trades.length === 0) break;
 
@@ -285,6 +307,7 @@ async function runTradesPass(
                     trade_id: t.trade_id,
                     ticker: t.ticker,
                 });
+                incrementItemsSkipped('trades', 'sentinel_created_time');
                 continue;
             }
             if (t.created_time <= watermarkIso) {
@@ -386,12 +409,14 @@ async function runRefreshPass<P, T>(
             );
         }
         const page = await opts.fetch(cursor, minUpdatedTs);
+        incrementPagesReceived(opts.scope);
         for (const item of opts.items(page)) {
             const skipReason = opts.skip?.(item);
             if (skipReason) {
                 log.warn(`skipping ${opts.label} item`, {
                     reason: skipReason,
                 });
+                incrementItemsSkipped(opts.table, skipReason);
                 skipped++;
                 continue;
             }


### PR DESCRIPTION
## Summary

Adds parity with the substreams-sink-sql metric surface so the public Token API Status dashboard can show Kalshi tip drift the same way it shows chain head drift for substreams sinks.

## Why

The existing scraper exports `scraper_completed_tasks_total`, `scraper_error_tasks_total`, `scraper_clickhouse_operations_seconds`, `scraper_rpc_requests_seconds`, `scraper_config_info` + default Node metrics. Missing: per-scope freshness, write-path throughput, quarantine signals — i.e. everything a chain-head-drift panel reads.

## Mapping to substreams-sink-sql

| Substreams metric | Kalshi equivalent |
|---|---|
| `head_block_number` | `scraper_head_time_seconds{service,scope}` (Unix ts) |
| `head_block_time_drift` | computed in Grafana as `time() - scraper_head_time_seconds` |
| `substreams_sink_backprocessing_completion` | `scraper_backfill_drained{service,scope}` |
| `substreams_sink_postgres_flushed_rows_count` | `scraper_rows_inserted_total{service,table}` |
| `substreams_sink_data_message` | `scraper_pages_received_total{service,scope}` |
| `substreams_sink_error` | existing `scraper_error_tasks_total` + new per-endpoint `scraper_http_errors_total` |
| `substreams_sink_postgres_store_flush_duration` | existing `scraper_clickhouse_operations_seconds` (histogram) |
| `substreams_sink_sql_info` | existing `scraper_config_info` |

Kalshi-specific additions (no substreams analogue):
- `scraper_poisoned{service,scope}` — quarantine alarm
- `scraper_items_skipped_total{service,table,reason}` — surfaces silent sentinel-timestamp skips
- `scraper_cycle_duration_seconds{service,outcome}` — wall-clock per `run()` cycle

## Wiring

- `lib/prometheus.ts:74` — new metric declarations + helpers
- `lib/service-init.ts:18` — caches service name via `setServiceNameLabel`
- `lib/batch-insert.ts:75` — `incrementRowsInserted(table, n)` after successful flush
- `services/kalshi/cursor.ts:73` — `setScopeHeadTime` on every cursor write
- `services/kalshi/backfill.ts:53` — reassert `drained` + `poisoned` gauges every cycle
- `services/kalshi/live.ts:86` — reassert `poisoned` for all scopes every cycle
- `services/kalshi/live.ts:284,357` — page + skip counters in trades + refresh passes
- `services/kalshi/client.ts:124` — `incrementHttpErrors(endpoint, status)` on final HTTP error
- `cli.ts:367,380` — `observeCycleDuration` wrapped around `serviceModule.run()`

## Cardinality

The `endpoint` label on `scraper_http_errors_total` is normalized by collapsing dynamic ticker segments via a regex (`/[A-Z][A-Z0-9_-]+` → `/{X}`), so the label set stays tied to the route surface (~8 endpoints), not the universe of Kalshi tickers.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)