### PR TITLE
feat(kalshi): fold markets + events into kalshi-backfill

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -58,7 +58,7 @@ const SERVICES = {
     'kalshi-backfill': {
         path: './services/kalshi/backfill.ts',
         description:
-            'Backfill the Kalshi `/historical/trades` archive (cutoff → oldest) into the shared trades table; resumable via cursor_state',
+            'Backfill the Kalshi cold-start state — trades (`/historical/trades`), settled markets (`/historical/markets`), and events (`/events` ungated) — into the shared kalshi.* tables; each pass resumable via its own cursor_state scope',
     },
     'metadata-solana-rpc': {
         path: './services/metadata-solana-rpc/index.ts',

--- a/services/kalshi/backfill.test.ts
+++ b/services/kalshi/backfill.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, mock, test } from 'bun:test';
 import {
     DRAINED_SENTINEL,
     POISONED_SENTINEL,
+    runEventsBackfill,
+    runMarketsBackfill,
     runTradesBackfill,
 } from './backfill';
-import type { Trade } from './types';
+import type { EventEntity, Market, Trade } from './types';
 
 function trade(overrides: Partial<Trade>): Trade {
     return {
@@ -429,5 +431,223 @@ describe('runTradesBackfill — defensive sentinel input', () => {
                 undefined,
             ),
         ).rejects.toThrow(/sentinel cursor/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Markets pass — mirrors a slim subset of the trades suite to validate the
+// generic walker is correctly parameterized for /historical/markets. The
+// trades suite covers the shared cursor / flush / quarantine machinery; here
+// we only re-prove what's pass-specific: endpoint, mapper, skip predicate,
+// and watermark source.
+// ---------------------------------------------------------------------------
+
+function market(overrides: Partial<Market>): Market {
+    return {
+        ticker: 'KXEX-1',
+        event_ticker: 'KXEX',
+        market_type: 'binary',
+        status: 'finalized',
+        title: 'Example',
+        created_time: '2026-03-01T00:00:00.000000Z',
+        updated_time: '2026-03-02T00:00:00.000000Z',
+        yes_bid_dollars: '0.50',
+        yes_ask_dollars: '0.50',
+        no_bid_dollars: '0.50',
+        no_ask_dollars: '0.50',
+        last_price_dollars: '0.50',
+        ...overrides,
+    };
+}
+
+interface MarketsPageSpec {
+    markets: Market[];
+    cursor: string;
+}
+
+function fakeMarketsClient(pages: MarketsPageSpec[]) {
+    let i = 0;
+    const calls: Array<{ cursor: string | undefined }> = [];
+    return {
+        calls,
+        getMarketsHistorical: (params: { cursor?: string }) => {
+            calls.push({ cursor: params.cursor });
+            const p = pages[i++];
+            if (!p) throw new Error(`fakeClient: no more pages (call #${i})`);
+            return Promise.resolve(p);
+        },
+    } as unknown as Parameters<typeof runMarketsBackfill>[0] & {
+        calls: Array<{ cursor: string | undefined }>;
+    };
+}
+
+describe('runMarketsBackfill', () => {
+    test('cold start sends no cursor and writes to the markets table', async () => {
+        const m = market({ ticker: 'KXEX-A' });
+        const client = fakeMarketsClient([{ markets: [m], cursor: '' }]);
+        const queue = fakeQueue();
+        const persist = spyPersist();
+        const result = await runMarketsBackfill(
+            client,
+            queue,
+            persist,
+            undefined,
+            undefined,
+        );
+        expect(client.calls[0]?.cursor).toBeUndefined();
+        expect(result.drained).toBe(true);
+        expect(queue.rows.at(-1)?.table).toBe('markets');
+        expect(persist.mock.calls.at(-1)?.[0]).toBe(DRAINED_SENTINEL);
+    });
+
+    test('skips markets with sentinel created_time AND sentinel updated_time', async () => {
+        const realMarket = market({ ticker: 'KXEX-REAL' });
+        const sentinelCreated = market({
+            ticker: 'KXEX-SC',
+            created_time: '0001-01-01T00:00:00.000000Z',
+        });
+        const sentinelUpdated = market({
+            ticker: 'KXEX-SU',
+            updated_time: '0001-01-01T00:00:00.000000Z',
+        });
+        const client = fakeMarketsClient([
+            {
+                markets: [realMarket, sentinelCreated, sentinelUpdated],
+                cursor: '',
+            },
+        ]);
+        const queue = fakeQueue();
+        const result = await runMarketsBackfill(
+            client,
+            queue,
+            spyPersist(),
+            undefined,
+            undefined,
+        );
+        expect(result.inserted).toBe(1);
+        expect(queue.rows.length).toBe(1);
+    });
+
+    test('watermark advances to the oldest created_time seen across pages', async () => {
+        const oldest = market({
+            ticker: 'KXEX-OLD',
+            created_time: '2026-01-15T00:00:00.000000Z',
+        });
+        const newer = market({
+            ticker: 'KXEX-NEW',
+            created_time: '2026-04-01T00:00:00.000000Z',
+        });
+        const client = fakeMarketsClient([
+            { markets: [newer], cursor: 'c1' },
+            { markets: [oldest], cursor: '' },
+        ]);
+        const result = await runMarketsBackfill(
+            client,
+            fakeQueue(),
+            spyPersist(),
+            undefined,
+            undefined,
+        );
+        expect(result.oldestSeen).toBe('2026-01-15T00:00:00.000000Z');
+    });
+
+    test('quarantines on cursor loop and persists POISONED_SENTINEL', async () => {
+        const m = market({ ticker: 'KXEX-LOOP' });
+        const client = fakeMarketsClient([
+            { markets: [m], cursor: 'loop' },
+            { markets: [m], cursor: 'loop' },
+        ]);
+        const persist = spyPersist();
+        await expect(
+            runMarketsBackfill(
+                client,
+                fakeQueue(),
+                persist,
+                undefined,
+                undefined,
+            ),
+        ).rejects.toThrow(/stale cursor back/);
+        expect(persist.mock.calls.at(-1)?.[0]).toBe(POISONED_SENTINEL);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Events pass — events have an optional `last_updated_ts`, no skip predicate,
+// and write to the events table.
+// ---------------------------------------------------------------------------
+
+function eventItem(overrides: Partial<EventEntity>): EventEntity {
+    return {
+        event_ticker: 'KXEX-EVT',
+        series_ticker: 'KXEX',
+        title: 'Example event',
+        last_updated_ts: '2026-03-01T00:00:00.000000Z',
+        ...overrides,
+    };
+}
+
+interface EventsPageSpec {
+    events: EventEntity[];
+    cursor: string;
+}
+
+function fakeEventsClient(pages: EventsPageSpec[]) {
+    let i = 0;
+    const calls: Array<{ cursor: string | undefined }> = [];
+    return {
+        calls,
+        getEvents: (params: { cursor?: string; min_updated_ts?: number }) => {
+            calls.push({ cursor: params.cursor });
+            if (params.min_updated_ts !== undefined) {
+                throw new Error(
+                    'events backfill must not send min_updated_ts (would gate to recent only)',
+                );
+            }
+            const p = pages[i++];
+            if (!p) throw new Error(`fakeClient: no more pages (call #${i})`);
+            return Promise.resolve(p);
+        },
+    } as unknown as Parameters<typeof runEventsBackfill>[0] & {
+        calls: Array<{ cursor: string | undefined }>;
+    };
+}
+
+describe('runEventsBackfill', () => {
+    test('cold start sends no cursor and no min_updated_ts; writes to events', async () => {
+        const e = eventItem({ event_ticker: 'KXEX-A' });
+        const client = fakeEventsClient([{ events: [e], cursor: '' }]);
+        const queue = fakeQueue();
+        const persist = spyPersist();
+        const result = await runEventsBackfill(
+            client,
+            queue,
+            persist,
+            undefined,
+            undefined,
+        );
+        expect(client.calls[0]?.cursor).toBeUndefined();
+        expect(result.drained).toBe(true);
+        expect(queue.rows.at(-1)?.table).toBe('events');
+        expect(persist.mock.calls.at(-1)?.[0]).toBe(DRAINED_SENTINEL);
+    });
+
+    test('events without last_updated_ts do not crash the pass — watermark falls back', async () => {
+        const e = eventItem({ event_ticker: 'KXEX-NO-TS' });
+        e.last_updated_ts = undefined;
+        const client = fakeEventsClient([{ events: [e], cursor: '' }]);
+        const persist = spyPersist();
+        const result = await runEventsBackfill(
+            client,
+            fakeQueue(),
+            persist,
+            undefined,
+            undefined,
+        );
+        expect(result.inserted).toBe(1);
+        // Last persist call still happened with DRAINED + a fallback ISO
+        // string (now()-derived) — the watermark column is non-null.
+        const lastCall = persist.mock.calls.at(-1);
+        expect(lastCall?.[0]).toBe(DRAINED_SENTINEL);
+        expect(lastCall?.[1]).toMatch(/^2\d{3}-/);
     });
 });

--- a/services/kalshi/backfill.ts
+++ b/services/kalshi/backfill.ts
@@ -1,7 +1,14 @@
-// Kalshi historical-trade backfill. Walks `/historical/trades` newest-first
-// from the cutoff backward, checkpointing per page so any process restart
-// resumes from the same cursor. One `run()` call = one bounded chunk
-// (`MAX_PAGES_PER_CYCLE`); the CLI runner cycles until the archive is drained.
+// Kalshi historical backfill — one process draining all of the public
+// "cold start" data we need to ship historical responses: trades (via
+// `/historical/trades`), settled markets (via `/historical/markets`), and
+// events (via the live `/events` endpoint without `min_updated_ts`, because
+// Kalshi exempts events from the cutoff partitioning — see
+// reference_kalshi_api.md `Live vs historical split`).
+//
+// Each pass walks its own scope independently; one `run()` call advances
+// each pass by at most `MAX_PAGES_PER_CYCLE` pages, then yields. The CLI
+// runner cycles until all three scopes hit `__DRAINED__`, after which the
+// service idles.
 
 import {
     getBatchInsertQueue,
@@ -18,34 +25,53 @@ import {
 } from '../../lib/prometheus';
 import { initService, markServiceAlive } from '../../lib/service-init';
 import { KalshiClient } from './client';
-import { getCursor, setCursor } from './cursor';
+import { type CursorCheckpoint, getCursors, setCursor } from './cursor';
 import { padIsoToMicroseconds } from './live';
-import { SENTINEL_TS_PREFIX, tradeRow } from './normalize';
+import { eventRow, marketRow, SENTINEL_TS_PREFIX, tradeRow } from './normalize';
+import type {
+    EventEntity,
+    EventsPage,
+    Market,
+    MarketsPage,
+    Trade,
+    TradesPage,
+} from './types';
 
 const serviceName = 'kalshi-backfill';
 const log = createLogger(serviceName);
 
-const SCOPE = 'trades_backfill';
+export const SCOPE_TRADES = 'trades_backfill';
+export const SCOPE_MARKETS = 'markets_backfill';
+export const SCOPE_EVENTS = 'events_backfill';
+const ALL_SCOPES = [SCOPE_TRADES, SCOPE_MARKETS, SCOPE_EVENTS] as const;
 
-/** Stored in `cursor_state.last_cursor` once the archive returns no further
- * pages on a productive cycle. Subsequent cycles short-circuit on this value
- * and idle quietly. */
+/** Stored in `cursor_state.last_cursor` once a pass returns no further pages
+ * on a productive cycle. Subsequent cycles short-circuit on this value and
+ * idle quietly. */
 export const DRAINED_SENTINEL = '__DRAINED__';
 
 /** Stored in `cursor_state.last_cursor` when the server returned a cursor we
  * already used (immediate self-loop or 2-hop alternation). Quarantines the
  * cursor so the next cycle doesn't re-enter the loop. Operator must clear
- * the row to resume backfilling. */
+ * the row to resume the pass. */
 export const POISONED_SENTINEL = '__POISONED__';
 
 const SENTINELS = new Set([DRAINED_SENTINEL, POISONED_SENTINEL]);
 
-/** Bounds the wall-clock work of a single `run()` call. The walker flushes
- * the batch queue and persists the resume cursor every page, so an interrupt
- * is always resumable from the last checkpoint. */
+/** Per-pass page budget within one `run()` call. Each pass flushes the batch
+ * queue and persists its cursor every page, so an interrupt is always
+ * resumable from the last checkpoint. */
 const MAX_PAGES_PER_CYCLE = 1000;
 
 type Queue = ReturnType<typeof getBatchInsertQueue>;
+
+/** Callback that durably persists the current pagination cursor + watermark
+ * for a single scope. Injected so each pass is testable without mocking the
+ * cursor module. */
+export type PersistCheckpoint = (
+    cursor: string,
+    watermarkIso: string,
+) => Promise<void>;
 
 export async function run(): Promise<void> {
     initService({ serviceName });
@@ -56,48 +82,63 @@ export async function run(): Promise<void> {
     let primaryError: unknown;
 
     try {
-        const prev = await getCursor(SCOPE);
-        // Reassert state gauges every cycle. If an operator clears the
-        // row the next cycle resets these to 0 without code changes.
-        setBackfillDrained(SCOPE, prev?.last_cursor === DRAINED_SENTINEL);
-        setScopePoisoned(SCOPE, prev?.last_cursor === POISONED_SENTINEL);
-        if (prev?.last_cursor === DRAINED_SENTINEL) {
-            log.info('backfill archive drained, idling', {
-                oldest_seen: prev.last_processed_ts_iso,
-            });
-            markServiceAlive();
-        } else if (prev?.last_cursor === POISONED_SENTINEL) {
-            log.warn(
-                'backfill quarantined — manual intervention required to resume',
-                { oldest_seen: prev.last_processed_ts_iso },
-            );
-            markServiceAlive();
-        } else {
-            await runTradesBackfill(
+        const cursors = await getCursors([...ALL_SCOPES]);
+        // Reassert gauges every cycle so an operator clearing the row is
+        // reflected immediately on the next /metrics scrape.
+        for (const scope of ALL_SCOPES) {
+            const c = cursors.get(scope);
+            setBackfillDrained(scope, c?.last_cursor === DRAINED_SENTINEL);
+            setScopePoisoned(scope, c?.last_cursor === POISONED_SENTINEL);
+        }
+
+        // Sequential — three short HTTP-bound walks share the same batch
+        // queue, so running them back-to-back keeps the queue's table-keyed
+        // buffers from interleaving. Each pass yields the queue clean.
+        await runPass(SCOPE_TRADES, 'trades', cursors, () =>
+            runTradesBackfill(
                 client,
                 queue,
-                (cursor, iso) => setCursor(SCOPE, cursor, iso),
-                prev?.last_cursor,
-                prev?.last_processed_ts_iso,
-            );
-            // Bump heartbeat once the walker returns cleanly — distinguishes
-            // an empty/no-progress cycle from a cycle that threw on a flush
-            // error (which deliberately leaves the heartbeat stale so the
-            // probe can catch silent insert loss).
-            markServiceAlive();
-        }
+                (c, t) => setCursor(SCOPE_TRADES, c, t),
+                cursors.get(SCOPE_TRADES)?.last_cursor,
+                cursors.get(SCOPE_TRADES)?.last_processed_ts_iso,
+            ),
+        );
+        await runPass(SCOPE_MARKETS, 'markets', cursors, () =>
+            runMarketsBackfill(
+                client,
+                queue,
+                (c, t) => setCursor(SCOPE_MARKETS, c, t),
+                cursors.get(SCOPE_MARKETS)?.last_cursor,
+                cursors.get(SCOPE_MARKETS)?.last_processed_ts_iso,
+            ),
+        );
+        await runPass(SCOPE_EVENTS, 'events', cursors, () =>
+            runEventsBackfill(
+                client,
+                queue,
+                (c, t) => setCursor(SCOPE_EVENTS, c, t),
+                cursors.get(SCOPE_EVENTS)?.last_cursor,
+                cursors.get(SCOPE_EVENTS)?.last_processed_ts_iso,
+            ),
+        );
+
+        // Heartbeat on every cycle — even when all three passes are drained
+        // (no walker ran). Without the bump an idle-but-healthy service
+        // would trip the liveness probe after the stale threshold.
+        markServiceAlive();
     } catch (error) {
         primaryError = error;
-        const err = error as Error;
+        const err = error as Error & { pass?: string };
         log.error('kalshi-backfill cycle failed', {
+            pass: err?.pass,
             message: err?.message ?? String(error),
             stack: err?.stack,
         });
     }
 
-    // Shutdown must run on both success and failure paths to flush in-flight
-    // rows. If the shutdown itself throws AND there's already a primary error,
-    // log+swallow the shutdown error so the original root cause survives.
+    // Shutdown runs on both paths to flush in-flight rows. If shutdown
+    // throws AND we already have a primary error, log+swallow so the
+    // original cycle error survives propagation.
     try {
         await shutdownBatchInsertQueue();
     } catch (shutdownErr) {
@@ -119,33 +160,83 @@ export async function run(): Promise<void> {
     incrementSuccess(serviceName);
 }
 
-/** Callback that durably persists the current pagination cursor + oldest
- * trade-ts ISO seen so far. Injected so the walker is testable without
- * mocking the cursor module. */
-export type PersistCheckpoint = (
-    cursor: string,
-    oldestSeenIso: string,
-) => Promise<void>;
+/** Run one pass with quarantine + drained short-circuits + per-pass error
+ * tagging. Returns true if the pass actually ran; false if it was skipped
+ * (drained or poisoned). */
+async function runPass(
+    scope: string,
+    label: string,
+    cursors: Map<string, CursorCheckpoint>,
+    body: () => Promise<unknown>,
+): Promise<boolean> {
+    const c = cursors.get(scope);
+    if (c?.last_cursor === DRAINED_SENTINEL) {
+        log.info(`${label} pass drained, idling`, {
+            scope,
+            oldest_seen: c.last_processed_ts_iso,
+        });
+        return false;
+    }
+    if (c?.last_cursor === POISONED_SENTINEL) {
+        log.warn(
+            `${label} pass quarantined — manual intervention required to resume`,
+            { scope, oldest_seen: c.last_processed_ts_iso },
+        );
+        return false;
+    }
+    try {
+        await body();
+        return true;
+    } catch (err) {
+        (err as Error & { pass?: string }).pass = label;
+        throw err;
+    }
+}
 
-export async function runTradesBackfill(
-    client: KalshiClient,
-    queue: Queue,
-    persist: PersistCheckpoint,
-    initialCursor: string | undefined,
-    initialOldestSeen: string | undefined,
-): Promise<{
+interface BackfillPassDeps<P, T> {
+    label: string;
+    scope: string;
+    table: string;
+    fetchPage: (cursor: string | undefined) => Promise<P>;
+    itemsOf: (page: P) => T[];
+    nextCursorOf: (page: P) => string | undefined;
+    mapper: (item: T) => Record<string, unknown>;
+    /** Returns a non-empty reason if the item must be dropped before
+     * `queue.add()` (sentinel timestamps that would null-out into a
+     * non-nullable CH column). */
+    skip?: (item: T) => string | undefined;
+    /** Returns the chronological timestamp used to advance the persisted
+     * watermark. Undefined for items without a meaningful timestamp — the
+     * pass falls back to the previous watermark or `now()`. */
+    watermarkOf: (item: T) => string | undefined;
+}
+
+interface PassResult {
     pages: number;
     inserted: number;
     drained: boolean;
     oldestSeen: string | undefined;
-}> {
-    // Defense-in-depth: the run() guard above already short-circuits on
+}
+
+/** Generic cursor-paginated backfill walker shared by trades / markets /
+ * events. The shape is identical across the three: cursor-paginate from an
+ * optional resume token, write rows to a table, persist `cursor + watermark`
+ * after every page, detect server-side loops, commit DRAINED_SENTINEL when
+ * the upstream cursor empties on a productive cycle. */
+async function runBackfillPass<P, T>(
+    queue: Queue,
+    persist: PersistCheckpoint,
+    initialCursor: string | undefined,
+    initialOldestSeen: string | undefined,
+    deps: BackfillPassDeps<P, T>,
+): Promise<PassResult> {
+    // Defense-in-depth: `runPass()` above already short-circuits on
     // sentinel values; this catches direct callers that forgot to mirror it.
     // Forwarding a sentinel to the Kalshi API would either 4xx or, worse,
     // silently restart the walk from the cutoff.
     if (initialCursor && SENTINELS.has(initialCursor)) {
         throw new Error(
-            `runTradesBackfill called with sentinel cursor ${initialCursor}; caller must short-circuit instead`,
+            `${deps.label} backfill called with sentinel cursor ${initialCursor}; caller must short-circuit instead`,
         );
     }
 
@@ -157,45 +248,40 @@ export async function runTradesBackfill(
     let drained = false;
 
     while (pages < MAX_PAGES_PER_CYCLE) {
-        const page = await client.getTradesHistorical({ cursor, limit: 1000 });
-        incrementPagesReceived(SCOPE);
+        const page = await deps.fetchPage(cursor);
+        incrementPagesReceived(deps.scope);
 
-        // Server hiccups (empty body / brief 200 with no content) return
-        // {trades: [], cursor: ''}. Distinguishing a true drain from a
-        // transient is impossible from a single empty response, so defer to
-        // the next CLI cycle instead of committing DRAINED_SENTINEL on flaky
-        // input. Matches the early-exit in live.ts.
-        if (page.trades.length === 0) {
-            log.info('backfill empty page, deferring drain decision', {
-                pages,
-                cursor_was: cursor,
-            });
+        const items = deps.itemsOf(page);
+        // Server hiccups (empty body / brief 200 with no content) return an
+        // empty items array with empty cursor. Distinguishing a true drain
+        // from a transient is impossible from a single empty response, so
+        // defer to the next cycle instead of committing DRAINED_SENTINEL on
+        // flaky input.
+        if (items.length === 0) {
+            log.info(
+                `${deps.label} backfill empty page, deferring drain decision`,
+                { pages, cursor_was: cursor },
+            );
             break;
         }
 
-        for (const t of page.trades) {
-            // Kalshi documents `0001-01-01T00:00:00Z` as a "never set"
-            // sentinel for unset timestamps. tradeRow() coerces it to null,
-            // which would then fail to insert into trades.created_time
-            // (non-nullable). Skip + warn so the cycle keeps advancing
-            // instead of poisoning the watermark and dropping a whole batch.
-            if (t.created_time.startsWith(SENTINEL_TS_PREFIX)) {
-                log.warn('skipping trade with sentinel created_time', {
-                    trade_id: t.trade_id,
-                    ticker: t.ticker,
-                });
-                incrementItemsSkipped('trades', 'sentinel_created_time');
+        for (const item of items) {
+            const skipReason = deps.skip?.(item);
+            if (skipReason) {
+                log.warn(`skipping ${deps.label} item`, { reason: skipReason });
+                incrementItemsSkipped(deps.table, skipReason);
                 continue;
             }
-            await queue.add('trades', tradeRow(t));
+            await queue.add(deps.table, deps.mapper(item));
             inserted++;
-            if (!oldestSeen || t.created_time < oldestSeen) {
-                oldestSeen = t.created_time;
+            const ts = deps.watermarkOf(item);
+            if (ts && (!oldestSeen || ts < oldestSeen)) {
+                oldestSeen = ts;
             }
         }
         pages++;
 
-        const nextCursor = page.cursor || undefined;
+        const nextCursor = deps.nextCursorOf(page);
 
         // Detect both immediate self-loop (server returns the cursor we just
         // sent) and 2-hop alternation (A → B → A).
@@ -203,15 +289,11 @@ export async function runTradesBackfill(
             !!nextCursor &&
             (nextCursor === cursor || nextCursor === prevCursor);
         if (isLoop) {
-            // Flush buffered trades for this page before quarantining the
+            // Flush buffered rows for this page before quarantining the
             // cursor. If the flush itself failed, do NOT persist
             // POISONED_SENTINEL: the spliced-out rows weren't written to CH
             // and quarantining would block the next cycle from re-fetching
-            // and re-inserting them. Throw with both signals so the operator
-            // sees both the loop and the flush failure. Mirror shutdown's
-            // check by also catching a lingering periodic-timer flush error
-            // (`!queue.isHealthy()`) that a subsequent partial-success flush
-            // hasn't cleared.
+            // and re-inserting them.
             const flushResults = await queue.flushAll();
             const flushFailed =
                 flushResults.includes('err') || !queue.isHealthy();
@@ -222,36 +304,31 @@ export async function runTradesBackfill(
             }
             throw new Error(
                 flushFailed
-                    ? 'backfill got a stale cursor back AND batch flush failed; cursor NOT quarantined to allow row recovery on retry'
-                    : 'backfill got a stale cursor back — server-side loop suspected; cursor quarantined',
+                    ? `${deps.label} backfill got a stale cursor back AND batch flush failed; cursor NOT quarantined to allow row recovery on retry`
+                    : `${deps.label} backfill got a stale cursor back — server-side loop suspected; cursor quarantined`,
             );
         }
 
         prevCursor = cursor;
         cursor = nextCursor;
 
-        // Flush buffered trades to CH before persisting the cursor advance.
-        // queue.add() only buffers — without this flush, a SIGKILL between
+        // Flush buffered rows to CH before persisting the cursor advance.
+        // `queue.add()` only buffers — without this flush, a SIGKILL between
         // persist and the next periodic batch tick would lose the just-
         // enqueued rows while the persisted cursor has already advanced
-        // past them (unrecoverable on opaque-cursor pagination).
-        // BatchInsertQueue catches and tags per-table flush errors as 'err'
-        // rather than throwing; abort the cycle on any err so the cursor
-        // doesn't advance past lost rows. Also check `!queue.isHealthy()`
-        // to catch a periodic-timer flush error that occurred between our
-        // explicit flushes and that the current batch's success didn't
-        // happen to clear (mirrors shutdown's combined check).
+        // past them. Also check `isHealthy()` to catch a periodic-timer
+        // flush error that this success didn't happen to clear.
         const results = await queue.flushAll();
         if (results.includes('err') || !queue.isHealthy()) {
             throw new Error(
-                'backfill aborting cycle — batch flush failed; cursor not advanced',
+                `${deps.label} backfill aborting cycle — batch flush failed; cursor not advanced`,
             );
         }
 
-        // `oldestSeen` is normally set after the first non-sentinel trade.
-        // The fallback handles the very rare case where every trade in the
-        // last productive page was a sentinel (we still need *some* value
-        // for the non-nullable CH column).
+        // `oldestSeen` is normally set after the first non-sentinel item.
+        // Fallback handles the rare case where every item on the final
+        // productive page was skipped (still need *some* value for the
+        // non-nullable CH column).
         const watermark = oldestSeen ?? padIsoToMicroseconds(Date.now());
         await persist(cursor ?? DRAINED_SENTINEL, watermark);
 
@@ -261,7 +338,7 @@ export async function runTradesBackfill(
         }
     }
 
-    log.info('backfill cycle', {
+    log.info(`${deps.label} backfill cycle`, {
         pages,
         inserted,
         drained,
@@ -270,4 +347,105 @@ export async function runTradesBackfill(
     });
 
     return { pages, inserted, drained, oldestSeen };
+}
+
+export function runTradesBackfill(
+    client: KalshiClient,
+    queue: Queue,
+    persist: PersistCheckpoint,
+    initialCursor: string | undefined,
+    initialOldestSeen: string | undefined,
+): Promise<PassResult> {
+    return runBackfillPass<TradesPage, Trade>(
+        queue,
+        persist,
+        initialCursor,
+        initialOldestSeen,
+        {
+            label: 'trades',
+            scope: SCOPE_TRADES,
+            table: 'trades',
+            fetchPage: (cursor) =>
+                client.getTradesHistorical({ cursor, limit: 1000 }),
+            itemsOf: (p) => p.trades,
+            nextCursorOf: (p) => p.cursor || undefined,
+            mapper: tradeRow,
+            // Kalshi documents `0001-01-01T00:00:00Z` as a "never set"
+            // sentinel. tradeRow() coerces to null, which fails to insert
+            // into trades.created_time (non-nullable).
+            skip: (t) =>
+                t.created_time.startsWith(SENTINEL_TS_PREFIX)
+                    ? 'sentinel_created_time'
+                    : undefined,
+            watermarkOf: (t) => t.created_time,
+        },
+    );
+}
+
+export function runMarketsBackfill(
+    client: KalshiClient,
+    queue: Queue,
+    persist: PersistCheckpoint,
+    initialCursor: string | undefined,
+    initialOldestSeen: string | undefined,
+): Promise<PassResult> {
+    return runBackfillPass<MarketsPage, Market>(
+        queue,
+        persist,
+        initialCursor,
+        initialOldestSeen,
+        {
+            label: 'markets',
+            scope: SCOPE_MARKETS,
+            table: 'markets',
+            fetchPage: (cursor) =>
+                client.getMarketsHistorical({ cursor, limit: 1000 }),
+            itemsOf: (p) => p.markets,
+            nextCursorOf: (p) => p.cursor || undefined,
+            mapper: marketRow,
+            // markets.created_time + markets.updated_time are non-nullable;
+            // skip rows whose sentinel timestamps would null-out on insert.
+            skip: (m) => {
+                if (m.created_time?.startsWith(SENTINEL_TS_PREFIX)) {
+                    return 'sentinel_created_time';
+                }
+                if (m.updated_time?.startsWith(SENTINEL_TS_PREFIX)) {
+                    return 'sentinel_updated_time';
+                }
+                return undefined;
+            },
+            watermarkOf: (m) => m.created_time,
+        },
+    );
+}
+
+export function runEventsBackfill(
+    client: KalshiClient,
+    queue: Queue,
+    persist: PersistCheckpoint,
+    initialCursor: string | undefined,
+    initialOldestSeen: string | undefined,
+): Promise<PassResult> {
+    return runBackfillPass<EventsPage, EventEntity>(
+        queue,
+        persist,
+        initialCursor,
+        initialOldestSeen,
+        {
+            label: 'events',
+            scope: SCOPE_EVENTS,
+            table: 'events',
+            // No `min_updated_ts` — Kalshi exempts events from the cutoff
+            // partitioning, so paginating live `/events` from cold-start
+            // walks the entire historical set. Live's events-refresh pass
+            // takes over via `min_updated_ts` once we drain.
+            fetchPage: (cursor) => client.getEvents({ cursor, limit: 200 }),
+            itemsOf: (p) => p.events,
+            nextCursorOf: (p) => p.cursor || undefined,
+            mapper: eventRow,
+            // eventRow() handles `0001-01-01` via ts() → null and
+            // events.last_updated_ts is Nullable, so no skip needed.
+            watermarkOf: (e) => e.last_updated_ts,
+        },
+    );
 }

--- a/services/kalshi/backfill.ts
+++ b/services/kalshi/backfill.ts
@@ -161,32 +161,30 @@ export async function run(): Promise<void> {
 }
 
 /** Run one pass with quarantine + drained short-circuits + per-pass error
- * tagging. Returns true if the pass actually ran; false if it was skipped
- * (drained or poisoned). */
+ * tagging. */
 async function runPass(
     scope: string,
     label: string,
     cursors: Map<string, CursorCheckpoint>,
     body: () => Promise<unknown>,
-): Promise<boolean> {
+): Promise<void> {
     const c = cursors.get(scope);
     if (c?.last_cursor === DRAINED_SENTINEL) {
         log.info(`${label} pass drained, idling`, {
             scope,
             oldest_seen: c.last_processed_ts_iso,
         });
-        return false;
+        return;
     }
     if (c?.last_cursor === POISONED_SENTINEL) {
         log.warn(
             `${label} pass quarantined — manual intervention required to resume`,
             { scope, oldest_seen: c.last_processed_ts_iso },
         );
-        return false;
+        return;
     }
     try {
         await body();
-        return true;
     } catch (err) {
         (err as Error & { pass?: string }).pass = label;
         throw err;

--- a/services/kalshi/client.ts
+++ b/services/kalshi/client.ts
@@ -196,6 +196,20 @@ export class KalshiClient {
         return this.get('/markets', { limit: 1000, ...params });
     }
 
+    /** Archived (before-cutoff) markets — settled markets that have rolled
+     * off the live `/markets` endpoint. Same response shape as `getMarkets`. */
+    getMarketsHistorical(
+        params: {
+            event_ticker?: string;
+            series_ticker?: string;
+            tickers?: string;
+            limit?: number;
+            cursor?: string;
+        } = {},
+    ): Promise<MarketsPage> {
+        return this.get('/historical/markets', { limit: 1000, ...params });
+    }
+
     getEvents(
         params: {
             status?: 'unopened' | 'open' | 'closed' | 'settled';


### PR DESCRIPTION
## Summary

`kalshi-backfill` becomes a three-pass service so a cold-start deployment captures everything our public `/v1/kalshi/*` endpoints need to serve historical data — not just trades.

- Trades pass: unchanged shape, walks \`/historical/trades\` (cutoff → oldest).
- **Markets pass** (new): walks \`/historical/markets\` to capture settled / finalized markets that have rolled off live \`/markets\`. Writes to the existing markets RMT — live's refresh-pass writes still win for any concurrently-touched market via RMT dedup by ticker.
- **Events pass** (new): paginates live \`/events\` without \`min_updated_ts\`. Kalshi exempts events from the cutoff partitioning (per the OpenAPI: *"All events are accessible through this endpoint, even if their associated markets are older than the historical cutoff"*), so there is no \`/historical/events\` to walk.

## Why

Without this, \`markets\` only contains the ~8.8k currently-active markets while \`trades\` references ~200k distinct tickers — so 99%+ of historical trade tickers have no market metadata. Same UX as Polymarket (\`/v1/polymarket/markets\` returns closed alongside open) requires the cold-start backfill to fill that gap.

## Design

Shared cursor / flush / loop-detect / quarantine machinery is extracted to a generic \`runBackfillPass<P, T>\` helper. The three wrappers only specify endpoint + mapper + skip predicate + watermark source.

| Pass | Endpoint | Skip predicate | Watermark | Scope |
|---|---|---|---|---|
| Trades | \`/historical/trades\` | sentinel \`created_time\` | \`t.created_time\` | \`trades_backfill\` |
| Markets | \`/historical/markets\` | sentinel \`created_time\` or \`updated_time\` | \`m.created_time\` | \`markets_backfill\` |
| Events | \`/events\` (no \`min_updated_ts\`) | (none — \`eventRow()\` handles sentinel via \`ts()\` and \`last_updated_ts\` is Nullable) | \`e.last_updated_ts\` (optional; falls back to \`now()\`) | \`events_backfill\` |

Each pass independently drains to \`__DRAINED__\` and the service idles when all three are done. Quarantine + flush semantics are identical to the existing trades pass.

## Notes

- Stacked on **#301** (metrics PR) — the new passes feed the \`scraper_backfill_drained\`, \`scraper_poisoned\`, \`scraper_pages_received_total\`, and \`scraper_items_skipped_total\` gauges/counters introduced there.
- Existing trades tests pass unchanged against the refactor (\`runTradesBackfill\` signature preserved). New markets + events test suites mirror a slim subset of the trades coverage.
- \`reference_kalshi_api.md\` was updated in the prior session to document the events/series cutoff exemption.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)