### PR TITLE
feat(kalshi): opt-in parallel backfill passes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,15 @@ AUTO_RESTART_DELAY=10
 # Number of days to look back for forked blocks (default: 30)
 FORKED_BLOCKS_DAYS_BACK=30
 
+# Kalshi Backfill Configuration
+# Run the trades / markets / events backfill passes concurrently within one
+# cycle instead of sequentially. Concurrent mode is faster when upstream RTT
+# dominates but couples per-pass failure detection through the shared batch
+# queue's `lastFlushError` flag — one pass's flush failure forces the others'
+# next-page check to abort too. Off by default; opt in once parallel cycles
+# have been observed safe.
+# KALSHI_BACKFILL_PARALLEL=false
+
 # Token Metadata Overrides
 # URL of a tokens.json file (e.g. GitHub raw) used to override on-chain name/symbol
 # with curated values for known tokens by updating matching metadata rows at startup.

--- a/services/kalshi/backfill.test.ts
+++ b/services/kalshi/backfill.test.ts
@@ -4,8 +4,10 @@ import {
     POISONED_SENTINEL,
     runEventsBackfill,
     runMarketsBackfill,
+    runPasses,
     runTradesBackfill,
 } from './backfill';
+import type { CursorCheckpoint } from './cursor';
 import type { EventEntity, Market, Trade } from './types';
 
 function trade(overrides: Partial<Trade>): Trade {
@@ -650,4 +652,272 @@ describe('runEventsBackfill', () => {
         expect(lastCall?.[0]).toBe(DRAINED_SENTINEL);
         expect(lastCall?.[1]).toMatch(/^2\d{3}-/);
     });
+});
+
+// ---------------------------------------------------------------------------
+// runPasses — sequential vs parallel orchestration. The shared per-pass
+// machinery is already covered above; here we only assert the cross-pass
+// scheduling + error-handling semantics that differ between modes.
+// ---------------------------------------------------------------------------
+
+interface GateClient {
+    getTradesHistorical: () => Promise<{ trades: Trade[]; cursor: string }>;
+    getMarketsHistorical: () => Promise<{ markets: Market[]; cursor: string }>;
+    getEvents: (params: {
+        min_updated_ts?: number;
+        cursor?: string;
+    }) => Promise<{ events: EventEntity[]; cursor: string }>;
+}
+
+/** Promise that resolves only when `release()` is called. Tracks observers
+ * for assertions like "did this fetch even start?". */
+function gate<T>(value: T) {
+    let resolveFn!: () => void;
+    let started = false;
+    const promise = new Promise<T>((res) => {
+        resolveFn = () => res(value);
+    });
+    return {
+        wait: () => {
+            started = true;
+            return promise;
+        },
+        release: () => resolveFn(),
+        get started() {
+            return started;
+        },
+    };
+}
+
+async function flushMicrotasks(n = 8): Promise<void> {
+    for (let i = 0; i < n; i++) {
+        await Promise.resolve();
+    }
+}
+
+const EMPTY_CURSORS = new Map<string, CursorCheckpoint>();
+
+describe('runPasses — scheduling', () => {
+    test('parallel mode kicks off all three passes before any completes', async () => {
+        const tradesGate = gate({ trades: [], cursor: '' });
+        const marketsGate = gate({ markets: [], cursor: '' });
+        const eventsGate = gate({ events: [], cursor: '' });
+        const client: GateClient = {
+            getTradesHistorical: () => tradesGate.wait(),
+            getMarketsHistorical: () => marketsGate.wait(),
+            getEvents: () => eventsGate.wait(),
+        };
+
+        const promise = runPasses(
+            client as unknown as Parameters<typeof runPasses>[0],
+            fakeQueue(),
+            EMPTY_CURSORS,
+            true,
+        );
+        await flushMicrotasks();
+
+        // All three fetchPage calls have hit the gate before any resolved.
+        expect(tradesGate.started).toBe(true);
+        expect(marketsGate.started).toBe(true);
+        expect(eventsGate.started).toBe(true);
+
+        tradesGate.release();
+        marketsGate.release();
+        eventsGate.release();
+        await promise;
+    });
+
+    test('sequential mode runs passes one at a time', async () => {
+        const tradesGate = gate({ trades: [], cursor: '' });
+        const marketsGate = gate({ markets: [], cursor: '' });
+        const eventsGate = gate({ events: [], cursor: '' });
+        const client: GateClient = {
+            getTradesHistorical: () => tradesGate.wait(),
+            getMarketsHistorical: () => marketsGate.wait(),
+            getEvents: () => eventsGate.wait(),
+        };
+
+        const promise = runPasses(
+            client as unknown as Parameters<typeof runPasses>[0],
+            fakeQueue(),
+            EMPTY_CURSORS,
+            false,
+        );
+        await flushMicrotasks();
+
+        // Only trades has started — markets + events must wait.
+        expect(tradesGate.started).toBe(true);
+        expect(marketsGate.started).toBe(false);
+        expect(eventsGate.started).toBe(false);
+
+        tradesGate.release();
+        await flushMicrotasks();
+        expect(marketsGate.started).toBe(true);
+        expect(eventsGate.started).toBe(false);
+
+        marketsGate.release();
+        await flushMicrotasks();
+        expect(eventsGate.started).toBe(true);
+
+        eventsGate.release();
+        await promise;
+    });
+});
+
+describe('runPasses — error propagation', () => {
+    test('parallel mode: failure in one pass does NOT cancel the others', async () => {
+        let marketsStarted = false;
+        let eventsStarted = false;
+        const client = {
+            getTradesHistorical: () => Promise.reject(new Error('trades boom')),
+            getMarketsHistorical: () => {
+                marketsStarted = true;
+                return Promise.resolve({ markets: [], cursor: '' });
+            },
+            getEvents: (_p: { min_updated_ts?: number; cursor?: string }) => {
+                eventsStarted = true;
+                return Promise.resolve({ events: [], cursor: '' });
+            },
+        };
+
+        await expect(
+            runPasses(
+                client as unknown as Parameters<typeof runPasses>[0],
+                fakeQueue(),
+                EMPTY_CURSORS,
+                true,
+            ),
+        ).rejects.toThrow(/trades boom/);
+
+        // markets + events still ran to completion (their fetches happened)
+        // even though trades rejected first — `allSettled` semantic.
+        expect(marketsStarted).toBe(true);
+        expect(eventsStarted).toBe(true);
+    });
+
+    test('sequential mode: failure in one pass halts subsequent passes', async () => {
+        let marketsStarted = false;
+        let eventsStarted = false;
+        const client = {
+            getTradesHistorical: () => Promise.reject(new Error('trades boom')),
+            getMarketsHistorical: () => {
+                marketsStarted = true;
+                return Promise.resolve({ markets: [], cursor: '' });
+            },
+            getEvents: (_p: { min_updated_ts?: number; cursor?: string }) => {
+                eventsStarted = true;
+                return Promise.resolve({ events: [], cursor: '' });
+            },
+        };
+
+        await expect(
+            runPasses(
+                client as unknown as Parameters<typeof runPasses>[0],
+                fakeQueue(),
+                EMPTY_CURSORS,
+                false,
+            ),
+        ).rejects.toThrow(/trades boom/);
+
+        // Sequential mode short-circuits on first failure.
+        expect(marketsStarted).toBe(false);
+        expect(eventsStarted).toBe(false);
+    });
+
+    test('error carries the failing pass label (parallel)', async () => {
+        const client = {
+            getTradesHistorical: () =>
+                Promise.resolve({ trades: [], cursor: '' }),
+            getMarketsHistorical: () =>
+                Promise.reject(new Error('markets boom')),
+            getEvents: () => Promise.resolve({ events: [], cursor: '' }),
+        };
+
+        try {
+            await runPasses(
+                client as unknown as Parameters<typeof runPasses>[0],
+                fakeQueue(),
+                EMPTY_CURSORS,
+                true,
+            );
+            throw new Error('expected runPasses to throw');
+        } catch (e) {
+            expect((e as Error & { pass?: string }).pass).toBe('markets');
+        }
+    });
+});
+
+describe('runPasses — sentinel short-circuits apply in both modes', () => {
+    function buildClient() {
+        const tradesCalled = { v: false };
+        const marketsCalled = { v: false };
+        const eventsCalled = { v: false };
+        const client = {
+            getTradesHistorical: () => {
+                tradesCalled.v = true;
+                return Promise.resolve({ trades: [], cursor: '' });
+            },
+            getMarketsHistorical: () => {
+                marketsCalled.v = true;
+                return Promise.resolve({ markets: [], cursor: '' });
+            },
+            getEvents: (_p: { min_updated_ts?: number; cursor?: string }) => {
+                eventsCalled.v = true;
+                return Promise.resolve({ events: [], cursor: '' });
+            },
+        };
+        return { client, tradesCalled, marketsCalled, eventsCalled };
+    }
+
+    function buildCursors(
+        overrides: Record<string, Partial<CursorCheckpoint>> = {},
+    ): Map<string, CursorCheckpoint> {
+        const m = new Map<string, CursorCheckpoint>();
+        for (const [scope, partial] of Object.entries(overrides)) {
+            m.set(scope, {
+                scope,
+                last_cursor: '',
+                last_processed_ts_ms: 0,
+                last_processed_ts_iso: '2026-01-01T00:00:00.000000Z',
+                ...partial,
+            });
+        }
+        return m;
+    }
+
+    for (const parallel of [true, false]) {
+        test(`drained scope is skipped (parallel=${parallel})`, async () => {
+            const { client, tradesCalled, marketsCalled, eventsCalled } =
+                buildClient();
+            const cursors = buildCursors({
+                trades_backfill: { last_cursor: DRAINED_SENTINEL },
+            });
+            await runPasses(
+                client as unknown as Parameters<typeof runPasses>[0],
+                fakeQueue(),
+                cursors,
+                parallel,
+            );
+            expect(tradesCalled.v).toBe(false);
+            expect(marketsCalled.v).toBe(true);
+            expect(eventsCalled.v).toBe(true);
+        });
+
+        test(`poisoned scope is skipped (parallel=${parallel})`, async () => {
+            const { client, tradesCalled, marketsCalled, eventsCalled } =
+                buildClient();
+            const cursors = buildCursors({
+                markets_backfill: { last_cursor: POISONED_SENTINEL },
+            });
+            await runPasses(
+                client as unknown as Parameters<typeof runPasses>[0],
+                fakeQueue(),
+                cursors,
+                parallel,
+            );
+            expect(tradesCalled.v).toBe(true);
+            expect(marketsCalled.v).toBe(false);
+            expect(eventsCalled.v).toBe(true);
+        });
+    }
 });

--- a/services/kalshi/backfill.ts
+++ b/services/kalshi/backfill.ts
@@ -63,6 +63,15 @@ const SENTINELS = new Set([DRAINED_SENTINEL, POISONED_SENTINEL]);
  * resumable from the last checkpoint. */
 const MAX_PAGES_PER_CYCLE = 1000;
 
+/** When true, the three backfill passes run concurrently within one cycle
+ * (via `Promise.allSettled`). Default sequential — concurrent mode is
+ * faster when upstream RTT dominates but shares the BatchInsertQueue's
+ * `lastFlushError` health across passes (one pass's flush failure forces
+ * the others' next-page check to abort too). Opt in via the env var. */
+function isParallelEnabled(): boolean {
+    return process.env.KALSHI_BACKFILL_PARALLEL === 'true';
+}
+
 type Queue = ReturnType<typeof getBatchInsertQueue>;
 
 /** Callback that durably persists the current pagination cursor + watermark
@@ -78,6 +87,7 @@ export async function run(): Promise<void> {
 
     const client = new KalshiClient();
     const queue = getBatchInsertQueue();
+    const parallel = isParallelEnabled();
 
     let primaryError: unknown;
 
@@ -91,36 +101,7 @@ export async function run(): Promise<void> {
             setScopePoisoned(scope, c?.last_cursor === POISONED_SENTINEL);
         }
 
-        // Sequential — three short HTTP-bound walks share the same batch
-        // queue, so running them back-to-back keeps the queue's table-keyed
-        // buffers from interleaving. Each pass yields the queue clean.
-        await runPass(SCOPE_TRADES, 'trades', cursors, () =>
-            runTradesBackfill(
-                client,
-                queue,
-                (c, t) => setCursor(SCOPE_TRADES, c, t),
-                cursors.get(SCOPE_TRADES)?.last_cursor,
-                cursors.get(SCOPE_TRADES)?.last_processed_ts_iso,
-            ),
-        );
-        await runPass(SCOPE_MARKETS, 'markets', cursors, () =>
-            runMarketsBackfill(
-                client,
-                queue,
-                (c, t) => setCursor(SCOPE_MARKETS, c, t),
-                cursors.get(SCOPE_MARKETS)?.last_cursor,
-                cursors.get(SCOPE_MARKETS)?.last_processed_ts_iso,
-            ),
-        );
-        await runPass(SCOPE_EVENTS, 'events', cursors, () =>
-            runEventsBackfill(
-                client,
-                queue,
-                (c, t) => setCursor(SCOPE_EVENTS, c, t),
-                cursors.get(SCOPE_EVENTS)?.last_cursor,
-                cursors.get(SCOPE_EVENTS)?.last_processed_ts_iso,
-            ),
-        );
+        await runPasses(client, queue, cursors, parallel);
 
         // Heartbeat on every cycle — even when all three passes are drained
         // (no walker ran). Without the bump an idle-but-healthy service
@@ -158,6 +139,88 @@ export async function run(): Promise<void> {
         throw primaryError;
     }
     incrementSuccess(serviceName);
+}
+
+/** Build the three pass invocations + run them either sequentially or
+ * concurrently based on `parallel`. Exported for unit testing. */
+export async function runPasses(
+    client: KalshiClient,
+    queue: Queue,
+    cursors: Map<string, CursorCheckpoint>,
+    parallel: boolean,
+): Promise<void> {
+    const passes: Array<{
+        scope: string;
+        label: string;
+        body: () => Promise<unknown>;
+    }> = [
+        {
+            scope: SCOPE_TRADES,
+            label: 'trades',
+            body: () =>
+                runTradesBackfill(
+                    client,
+                    queue,
+                    (c, t) => setCursor(SCOPE_TRADES, c, t),
+                    cursors.get(SCOPE_TRADES)?.last_cursor,
+                    cursors.get(SCOPE_TRADES)?.last_processed_ts_iso,
+                ),
+        },
+        {
+            scope: SCOPE_MARKETS,
+            label: 'markets',
+            body: () =>
+                runMarketsBackfill(
+                    client,
+                    queue,
+                    (c, t) => setCursor(SCOPE_MARKETS, c, t),
+                    cursors.get(SCOPE_MARKETS)?.last_cursor,
+                    cursors.get(SCOPE_MARKETS)?.last_processed_ts_iso,
+                ),
+        },
+        {
+            scope: SCOPE_EVENTS,
+            label: 'events',
+            body: () =>
+                runEventsBackfill(
+                    client,
+                    queue,
+                    (c, t) => setCursor(SCOPE_EVENTS, c, t),
+                    cursors.get(SCOPE_EVENTS)?.last_cursor,
+                    cursors.get(SCOPE_EVENTS)?.last_processed_ts_iso,
+                ),
+        },
+    ];
+
+    if (parallel) {
+        // `allSettled` so a failure in one pass doesn't cancel the others
+        // — passes write to independent CH tables + cursor scopes, so
+        // partial-cycle progress is durable per-pass. Aggregate failures
+        // afterward; the first one carries through with its pass label.
+        const results = await Promise.allSettled(
+            passes.map((p) => runPass(p.scope, p.label, cursors, p.body)),
+        );
+        const failures = results
+            .map((r, i) => ({ r, label: passes[i]?.label ?? '' }))
+            .filter(({ r }) => r.status === 'rejected');
+        if (failures.length > 1) {
+            for (const f of failures) {
+                const reason = (f.r as PromiseRejectedResult).reason;
+                log.error('parallel backfill pass failed', {
+                    pass: f.label,
+                    message: (reason as Error)?.message ?? String(reason),
+                });
+            }
+        }
+        if (failures.length > 0) {
+            throw (failures[0]!.r as PromiseRejectedResult).reason;
+        }
+        return;
+    }
+
+    for (const p of passes) {
+        await runPass(p.scope, p.label, cursors, p.body);
+    }
 }
 
 /** Run one pass with quarantine + drained short-circuits + per-pass error


### PR DESCRIPTION
## Summary

The trades / markets / events backfill passes currently run sequentially within one cycle, which stretches one full cycle to ~10–15min once all three are walking (vs ~3min for trades alone on the previous single-pass shape). The passes are HTTP-bound and write to independent CH tables + cursor scopes, so concurrency is safe.

Adds `KALSHI_BACKFILL_PARALLEL=true` opt-in. When set, the three passes run via `Promise.allSettled` within one cycle. Default stays sequential — opt in only after observing parallel cycles healthy.

## Trade-off

The `BatchInsertQueue` `lastFlushError` health flag is module-level, so in concurrent mode one pass's flush failure forces the others' next-page `!queue.isHealthy()` check to abort too. That's "fail safe" — overly eager rather than silently dropping rows — and the simpler design vs per-pass queue isolation.

## Code references

- `services/kalshi/backfill.ts:71` — `isParallelEnabled()` env-var reader.
- `services/kalshi/backfill.ts:146` — `runPasses()` extracted + exported. Switches on `parallel` between sequential `for await` and `Promise.allSettled`.
- `services/kalshi/backfill.ts:195` — `allSettled` failure aggregation: first rejection rethrows with its pass label intact, additional failures are logged.
- `services/kalshi/backfill.test.ts:660` onward — 9 new tests covering scheduling, error propagation, and sentinel short-circuits in both modes.
- `.env.example:48` — documents the new `KALSHI_BACKFILL_PARALLEL` flag.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)