### PR TITLE
feat(hyperliquid): recover settled outcomes' question_id from settledOutcome

### DIFF
--- a/services/hyperliquid/outcomes-info.test.ts
+++ b/services/hyperliquid/outcomes-info.test.ts
@@ -4,6 +4,7 @@ import {
     buildOutcomeToQuestion,
     buildQuestionRow,
     buildSettledOutcomeRow,
+    extractSettledQuestionId,
     fetchOutcomeMeta,
     fetchSettledOutcome,
     type HyperliquidOutcomeMeta,
@@ -126,6 +127,56 @@ describe('buildSettledOutcomeRow', () => {
             REFRESH,
         );
         expect(row.settle_fraction).toBeNull();
+    });
+});
+
+describe('extractSettledQuestionId', () => {
+    const baseSettled: HyperliquidSettledOutcome = {
+        spec: {
+            outcome: 318,
+            name: 'Germany',
+            description: 'Resolves to Yes if Germany wins the Game.',
+            sideSpecs: [{ name: 'Yes' }, { name: 'No' }],
+            quoteToken: 'USDC',
+        },
+        settleFraction: '1.0',
+        details: 'FIFA declared Germany the winner.',
+    };
+
+    test('returns the settled question id when the parent question has fully resolved', () => {
+        const settled: HyperliquidSettledOutcome = {
+            ...baseSettled,
+            question: {
+                question: { settled: 54 },
+                name: 'World Cup: Germany vs Curacao',
+                description: '...',
+            },
+        };
+        expect(extractSettledQuestionId(settled)).toBe(54);
+    });
+
+    test('returns the live question id when the parent question is still ongoing', () => {
+        const settled: HyperliquidSettledOutcome = {
+            ...baseSettled,
+            question: {
+                question: { live: 32 },
+                name: '2026 World Cup Champion',
+                description: '...',
+            },
+        };
+        expect(extractSettledQuestionId(settled)).toBe(32);
+    });
+
+    test('returns null for binary single-outcome markets (no question wrapper)', () => {
+        expect(extractSettledQuestionId(baseSettled)).toBeNull();
+    });
+
+    test('returns null when the wrapper is present but the discriminator is empty', () => {
+        const settled: HyperliquidSettledOutcome = {
+            ...baseSettled,
+            question: { question: {}, name: '', description: '' },
+        };
+        expect(extractSettledQuestionId(settled)).toBeNull();
     });
 });
 

--- a/services/hyperliquid/outcomes-info.ts
+++ b/services/hyperliquid/outcomes-info.ts
@@ -54,14 +54,35 @@ export interface HyperliquidOutcomeMeta {
 }
 
 /**
+ * Question wrapper carried on the `settledOutcome` response — present when the
+ * outcome belongs to a multi-outcome question. The inner `question` discriminator
+ * indicates the parent question's lifecycle: `{settled: N}` for a fully-settled
+ * question that has dropped from `outcomeMeta`, `{live: N}` for a still-active
+ * parent (some sibling outcomes resolved, others ongoing).
+ *
+ * HL only emits this block for outcomes that belonged to a question; binary
+ * single-outcome markets resolve without a wrapper.
+ */
+export interface HyperliquidSettledOutcomeQuestion {
+    question: { settled?: number; live?: number };
+    name: string;
+    description: string;
+}
+
+/**
  * Settlement payload returned by `POST /info {type: settledOutcome, outcome: N}`
  * when the outcome has resolved. Returns `null` (top-level) for outcomes still
  * live — callers must distinguish that case before parsing.
+ *
+ * `question` is absent for binary single-outcome markets and populated for
+ * multi-outcome markets — this is the only path to recover the parent question
+ * id once the question has dropped from `outcomeMeta`.
  */
 export interface HyperliquidSettledOutcome {
     spec: HyperliquidOutcomeSpec;
     settleFraction: string;
     details: string;
+    question?: HyperliquidSettledOutcomeQuestion;
 }
 
 /** Row shape inserted into `state_outcome_meta`. */
@@ -156,6 +177,22 @@ export async function fetchSettledOutcome(
         return null;
     }
     return body;
+}
+
+/**
+ * Extract the parent question id from a `settledOutcome` response. Reads from
+ * `question.question.{settled,live}` and returns the first defined of the two.
+ * Returns `null` for binary single-outcome markets (no `question` wrapper)
+ * or when the wrapper is present but neither key carries a number.
+ */
+export function extractSettledQuestionId(
+    settled: HyperliquidSettledOutcome,
+): number | null {
+    const q = settled.question?.question;
+    if (!q) return null;
+    if (typeof q.settled === 'number') return q.settled;
+    if (typeof q.live === 'number') return q.live;
+    return null;
 }
 
 /**

--- a/services/hyperliquid/outcomes.test.ts
+++ b/services/hyperliquid/outcomes.test.ts
@@ -263,6 +263,64 @@ describe('hyperliquid runOutcomesCycle()', () => {
         expect(mockMarkServiceAlive).not.toHaveBeenCalled();
     });
 
+    test('recovers question_id from settledOutcome wrapper when live map has no entry', async () => {
+        // outcome 318 (Germany) belonged to question 54 (Germany vs Curacao),
+        // which has fully settled and dropped from outcomeMeta. The live map
+        // can't link it back, but the settledOutcome response still carries
+        // the parent question id under `question.question.settled`.
+        mockQuery.mockImplementation(
+            mockQueryRouter({
+                knownIds: ['318'],
+                alreadySettled: [],
+            }),
+        );
+        globalThis.fetch = mock((_url: string, init: RequestInit) => {
+            const body = JSON.parse(init.body as string);
+            if (body.type === 'outcomeMeta') {
+                return Promise.resolve(
+                    new Response(JSON.stringify(liveBody), { status: 200 }),
+                );
+            }
+            if (body.type === 'settledOutcome' && body.outcome === 318) {
+                return Promise.resolve(
+                    new Response(
+                        JSON.stringify({
+                            spec: {
+                                outcome: 318,
+                                name: 'Germany',
+                                description: 'Resolves Yes if Germany wins.',
+                                sideSpecs: [{ name: 'Yes' }, { name: 'No' }],
+                                quoteToken: 'USDC',
+                            },
+                            settleFraction: '1.0',
+                            details: 'FIFA declared Germany the winner.',
+                            question: {
+                                question: { settled: 54 },
+                                name: 'World Cup: Germany vs Curacao',
+                                description:
+                                    'This market has three possible outcomes...',
+                            },
+                        }),
+                        { status: 200 },
+                    ),
+                );
+            }
+            return Promise.resolve(new Response('null', { status: 200 }));
+        }) as unknown as typeof fetch;
+
+        const { runOutcomesCycle } = await import('./outcomes');
+        await runOutcomesCycle('http://example/info');
+
+        const outcomeCall = mockInsert.mock.calls
+            .map((c) => c[0] as InsertCallArg)
+            .find((c) => c.table === 'state_outcome_meta');
+        const settled318 = outcomeCall!.values.find(
+            (r) => r.outcome_id === 318,
+        );
+        expect(settled318?.status).toBe('settled');
+        expect(settled318?.question_id).toBe(54);
+    });
+
     test('returns early without inserting when outcomeMeta is empty', async () => {
         globalThis.fetch = mock(() =>
             Promise.resolve(

--- a/services/hyperliquid/outcomes.ts
+++ b/services/hyperliquid/outcomes.ts
@@ -7,6 +7,7 @@ import {
     buildOutcomeToQuestion,
     buildQuestionRow,
     buildSettledOutcomeRow,
+    extractSettledQuestionId,
     fetchOutcomeMeta,
     fetchSettledOutcome,
     type OutcomeMetaRow,
@@ -43,14 +44,17 @@ async function fetchKnownOutcomeIds(): Promise<Set<number>> {
 }
 
 /**
- * Discover outcome_ids we've already captured as `status='settled'`. Settled
- * payloads are immutable on the HL side, so once we have one we never need to
- * re-probe — skipping them turns the steady-state cycle into a no-op on the
- * Info API even as the cumulative settled universe grows.
+ * Discover outcome_ids we've already captured as `status='settled'` *with* a
+ * populated `question_id`. Once both are written the row is terminal — settled
+ * payloads are immutable on the HL side, so skipping them turns the steady-state
+ * cycle into a no-op on the Info API even as the cumulative settled universe
+ * grows. Rows with `status='settled' AND question_id IS NULL` are orphans
+ * (early scraper missed the multi-outcome question link) and stay eligible for
+ * re-probe so they self-heal on the next cycle.
  */
 async function fetchAlreadySettledIds(): Promise<Set<number>> {
     const { data } = await query<{ outcome_id: string }>(
-        "SELECT toString(outcome_id) AS outcome_id FROM state_outcome_meta FINAL WHERE status = 'settled'",
+        "SELECT toString(outcome_id) AS outcome_id FROM state_outcome_meta FINAL WHERE status = 'settled' AND question_id IS NOT NULL",
     );
     return parseUint64Set(data);
 }
@@ -162,7 +166,8 @@ export async function runOutcomesCycle(infoUrl: string): Promise<void> {
                     outcomeRows.push(
                         buildSettledOutcomeRow(
                             s,
-                            outcomeToQuestion.get(s.spec.outcome) ?? null,
+                            outcomeToQuestion.get(s.spec.outcome) ??
+                                extractSettledQuestionId(s),
                             refresh_time,
                         ),
                     );


### PR DESCRIPTION
## Summary

When a multi-outcome question fully resolves (e.g. \"World Cup: Germany vs Curacao\"), HL drops it from \`outcomeMeta\`. The live \`outcomeToQuestion\` map then can't link the settled child outcomes back to their parent, so they land in \`state_outcome_meta\` with \`question_id=null\` and downstream consumers lose the grouping.

HL still exposes the link on the \`settledOutcome\` response under \`question.question.{settled|live}\`. This change:

- Extends \`HyperliquidSettledOutcome\` to type the optional \`question\` wrapper and adds \`extractSettledQuestionId\` as the extraction helper.
- Falls back to that extractor in \`outcomes.ts\` when the live map has no entry — covering both lifecycle states (parent still active vs fully settled).
- Narrows the already-settled guard to \`status='settled' AND question_id IS NOT NULL\`. Previously-orphaned rows get re-probed once on the next cycle and self-heal via the RMT collapse.

Binary single-outcome markets continue to re-probe each cycle (no parent to find, write is idempotent) — small steady-state cost in exchange for not adding a separate \"probed completely\" sentinel to the schema.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)